### PR TITLE
remove locks on sender-side of mpsc channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] Q1 2023
+ - fixed redundant locking on twin
+
 ## [0.8.1] Q1 2023
  - twin:
    - refactored into main module and submodules:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-device-service"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "azure-iot-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnect-device-service"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "This service allows remote features like: user fw update consent, factory reset, network adapter status and reboot."
 authors = ["omnect@conplement.de"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use log::{error, info};
 use notify::RecursiveMode;
 use notify_debouncer_mini::new_debouncer;
 use std::fs;
-use std::sync::{mpsc, Arc, Mutex, Once};
+use std::sync::{mpsc, Once};
 use std::{path::Path, time::Duration};
 use twin::ReportProperty;
 #[cfg(test)]
@@ -67,12 +67,11 @@ pub async fn run() -> Result<()> {
     let (tx_client2app, rx_client2app) = mpsc::channel();
     let (tx_app2client, rx_app2client) = mpsc::channel();
     let (tx_file2app, rx_file2app) = mpsc::channel();
-    let tx_app2client = Arc::new(Mutex::new(tx_app2client));
     let mut debouncer =
         new_debouncer(Duration::from_secs(WATCHER_DELAY), None, tx_file2app).unwrap();
     let request_consent_path = format!("{}/request_consent.json", consent_path!());
     let history_consent_path = format!("{}/history_consent.json", consent_path!());
-    let twin = twin::get_or_init(Some(Arc::clone(&tx_app2client)));
+    let twin = twin::get_or_init(Some(&tx_app2client));
 
     debouncer
         .watcher()

--- a/src/twin/mod.rs
+++ b/src/twin/mod.rs
@@ -11,7 +11,7 @@ use azure_iot_sdk::client::*;
 use log::{info, warn};
 use once_cell::sync::OnceCell;
 use std::sync::mpsc::Sender;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Mutex, MutexGuard};
 
 static INSTANCE: OnceCell<Mutex<Twin>> = OnceCell::new();
 
@@ -19,12 +19,12 @@ pub struct TwinInstance {
     inner: &'static Mutex<Twin>,
 }
 
-pub fn get_or_init(tx: Option<Arc<Mutex<Sender<Message>>>>) -> TwinInstance {
-    if tx.is_some() {
+pub fn get_or_init(tx: Option<& Sender<Message>>) -> TwinInstance {
+    if let Some(tx) = tx {
         TwinInstance {
             inner: INSTANCE.get_or_init(|| {
                 Mutex::new(Twin {
-                    tx,
+                    tx: Some(tx.clone()),
                     ..Default::default()
                 })
             }),
@@ -90,7 +90,7 @@ impl TwinInstance {
 
 #[derive(Default)]
 struct Twin {
-    tx: Option<Arc<Mutex<Sender<Message>>>>,
+    tx: Option<Sender<Message>>,
     include_network_filter: Option<Vec<String>>,
 }
 
@@ -146,8 +146,6 @@ impl Twin {
         self.tx
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("tx channel missing"))?
-            .lock()
-            .unwrap()
             .send(Message::Reported(value))
             .map_err(|err| err.into())
     }

--- a/src/twin/mod_test.rs
+++ b/src/twin/mod_test.rs
@@ -6,7 +6,7 @@ mod mod_test {
     use serde_json::json;
     use std::env;
     use std::sync::mpsc::TryRecvError;
-    use std::sync::{mpsc, Arc, Mutex};
+    use std::sync::{mpsc, Mutex};
     use stdext::function_name;
 
     /* ToDo:
@@ -31,7 +31,6 @@ mod mod_test {
             .starts_with("tx channel missing"));
 
         let (tx, rx) = mpsc::channel();
-        let tx = Arc::new(Mutex::new(tx));
         let mut twin = Twin {
             tx: Some(tx),
             include_network_filter: None,
@@ -47,7 +46,6 @@ mod mod_test {
     #[test]
     fn report_versions_test() {
         let (tx, rx) = mpsc::channel();
-        let tx = Arc::new(Mutex::new(tx));
         let mut twin = Twin {
             tx: Some(tx),
             include_network_filter: None,
@@ -67,7 +65,6 @@ mod mod_test {
     #[test]
     fn update_and_report_general_consent_test() {
         let (tx, rx) = mpsc::channel();
-        let tx = Arc::new(Mutex::new(tx));
         let mut twin = Twin {
             tx: Some(tx),
             include_network_filter: None,
@@ -144,7 +141,6 @@ mod mod_test {
     #[test]
     fn report_user_consent_test() {
         let (tx, rx) = mpsc::channel();
-        let tx = Arc::new(Mutex::new(tx));
         let mut twin = Twin {
             tx: Some(tx),
             include_network_filter: None,
@@ -191,7 +187,6 @@ mod mod_test {
     #[test]
     fn report_factory_reset_status_test() {
         let (tx, rx) = mpsc::channel();
-        let tx = Arc::new(Mutex::new(tx));
         let mut twin = Twin {
             tx: Some(tx),
             include_network_filter: None,
@@ -214,7 +209,6 @@ mod mod_test {
     #[test]
     fn report_factory_reset_result_test() {
         let (tx, rx) = mpsc::channel();
-        let tx = Arc::new(Mutex::new(tx));
         let mut twin = Twin {
             tx: Some(tx),
             include_network_filter: None,
@@ -232,7 +226,6 @@ mod mod_test {
     #[test]
     fn update_and_report_network_status_test() {
         let (tx, rx) = mpsc::channel();
-        let tx = Arc::new(Mutex::new(tx));
         let mut twin = Twin {
             tx: Some(tx),
             include_network_filter: None,


### PR DESCRIPTION
Remove the locks on the shared app2client Sender. Senders implement the Send Trait. This allows them to be shared by copying and moving them to other threads (for example, see the "Shared Usage" example in https://doc.rust-lang.org/std/sync/mpsc).

This simplifies the function calls and the unpacking logic. Furthermore, this reduces overall locking, as the Sender internally takes care of synchronization.

Note: Tested against the unittests, but not IoT hub.

Related: https://github.com/omnect/iot-client-template-rs/pull/38#issue-1604858884