### PR TITLE
fix: modem manager support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2017,8 +2017,8 @@ dependencies = [
 
 [[package]]
 name = "modemmanager"
-version = "0.2.0"
-source = "git+https://github.com/omnect/modemmanager.git?tag=0.2.0#f73a309dca5161131ac3c0bb077255c21dfa439a"
+version = "0.3.0"
+source = "git+https://github.com/omnect/modemmanager.git?tag=0.3.0#bbf1acf77e2b28c312daeef4527ea9056fc15afe"
 dependencies = [
  "modemmanager-sys",
  "num",
@@ -2230,7 +2230,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-device-service"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "actix-server",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-device-service"
 readme = "README.md"
 repository = "git@github.com:omnect/omnect-device-service.git"
-version = "0.19.0"
+version = "0.19.1"
 
 [dependencies]
 actix-server = "2.3"
@@ -28,7 +28,7 @@ futures-util = "0.3"
 lazy_static = "1.4"
 log = "0.4"
 log-panics = { version = "2", features = ["with-backtrace"] }
-modemmanager = { git = "https://github.com/omnect/modemmanager.git", tag = "0.2.0", default_features = false, optional = true }
+modemmanager = { git = "https://github.com/omnect/modemmanager.git", tag = "0.3.0", default_features = false, optional = true }
 network-interface = "0.1"
 nix = { version = "0.28", features = ["time"] }
 notify = "6.0"

--- a/src/bootloader_env/mod.rs
+++ b/src/bootloader_env/mod.rs
@@ -5,9 +5,15 @@ mod uboot;
 
 use anyhow::Result;
 #[cfg(feature = "bootloader_grub")]
-use grub::{bootloader_env as get_inner, set_bootloader_env as set_inner, unset_bootloader_env as unset_inner};
+use grub::{
+    bootloader_env as get_inner, set_bootloader_env as set_inner,
+    unset_bootloader_env as unset_inner,
+};
 #[cfg(feature = "bootloader_uboot")]
-use uboot::{bootloader_env as get_inner, set_bootloader_env as set_inner, unset_bootloader_env as unset_inner};
+use uboot::{
+    bootloader_env as get_inner, set_bootloader_env as set_inner,
+    unset_bootloader_env as unset_inner,
+};
 
 #[allow(unreachable_code, unused_variables)]
 pub fn get(key: &str) -> Result<String> {

--- a/src/systemd/mod.rs
+++ b/src/systemd/mod.rs
@@ -1,7 +1,6 @@
 pub mod unit;
 pub mod watchdog;
 
-
 #[cfg(not(feature = "mock"))]
 use anyhow::Context;
 use anyhow::{bail, Result};
@@ -9,20 +8,16 @@ use log::{debug, info};
 use sd_notify::NotifyState;
 #[cfg(not(feature = "mock"))]
 use std::process::Command;
-use std::{
-    sync::Once,
-    thread, time,
-    time::Duration,
-};
+use std::{sync::Once, thread, time, time::Duration};
 use systemd_zbus::ManagerProxy;
 use tokio::time::{timeout_at, Instant};
 
 pub fn sd_notify_ready() {
-  static SD_NOTIFY_ONCE: Once = Once::new();
-  SD_NOTIFY_ONCE.call_once(|| {
-      info!("notify ready=1");
-      let _ = sd_notify::notify(false, &[NotifyState::Ready]);
-  });
+    static SD_NOTIFY_ONCE: Once = Once::new();
+    SD_NOTIFY_ONCE.call_once(|| {
+        info!("notify ready=1");
+        let _ = sd_notify::notify(false, &[NotifyState::Ready]);
+    });
 }
 
 #[cfg(not(feature = "mock"))]

--- a/src/twin/modem_info.rs
+++ b/src/twin/modem_info.rs
@@ -193,7 +193,7 @@ mod inner {
             Ok(SimProperties { operator, iccid })
         }
 
-        async fn sim_properties<'a>(
+        async fn sims_properties<'a>(
             &self,
             modem: &modem::ModemProxy<'a>,
         ) -> Result<Vec<SimProperties>> {
@@ -232,7 +232,7 @@ mod inner {
             let revision = modem.revision().await?;
             let preferred_technologies = modem.supported_capabilities().await?;
             let bearers = self.bearer_properties(&modem).await?;
-            let sims = self.sim_properties(&modem).await?;
+            let sims = self.sims_properties(&modem).await?;
 
             let connection = self.connection().await?;
             let dbus = DBusProxy::new(connection).await?;


### PR DESCRIPTION
We adapt for version 0.3.0 of the modemmanager crate. With this we resolve issues with modemmanager replies that could not be parsed properly. We resolve this by keeping the bearer information as it is and directly converting it to JSON, without an additional conversion into an internal data structure. This will hopefully make the modem info feature more robust in the future. 