### PR TITLE
feat: async iotclient startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,8 +632,8 @@ dependencies = [
 
 [[package]]
 name = "azure-iot-sdk"
-version = "0.13.2"
-source = "git+https://github.com/omnect/azure-iot-sdk.git?tag=0.13.2#b3cc4956b6fd071d0585232d114953c5c821dbf4"
+version = "0.13.3"
+source = "git+https://github.com/omnect/azure-iot-sdk.git?tag=0.13.3#d3907f5b6f887dd601cee626612ae7ca649af0b7"
 dependencies = [
  "anyhow",
  "azure-iot-sdk-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-device-service"
-version = "0.22.4"
+version = "0.23.0"
 dependencies = [
  "actix-server",
  "actix-web",
@@ -2468,6 +2468,7 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
+ "tokio-stream",
  "toml",
  "uuid",
  "x509-parser",
@@ -3505,6 +3506,17 @@ checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-device-service"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-device-service.git"
-version = "0.22.4"
+version = "0.23.0"
 
 [dependencies]
 actix-server = "2.3"
@@ -48,6 +48,7 @@ strum_macros = "0.26"
 systemd-zbus = "0.1"
 time = { version = "=0.3", features = ["formatting"] }
 tokio = "1"
+tokio-stream = "0.1"
 toml = "0.8"
 uuid = "1.4"
 x509-parser = "=0.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ actix-server = "2.3"
 actix-web = "4.5"
 anyhow = "1.0"
 async-trait = "0.1"
-azure-iot-sdk = { git = "https://github.com/omnect/azure-iot-sdk.git", tag = "0.13.2", features = [
+azure-iot-sdk = { git = "https://github.com/omnect/azure-iot-sdk.git", tag = "0.13.3", features = [
   "module_client",
 ] }
 cfg-if = "1.0"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This module serves as interface between omnect cloud and device to support certa
     - [Wifi commissioning service](#wifi-commissioning-service)
       - [Feature availability](#feature-availability-7)
   - [Local web service](#local-web-service)
+    - [Factory reset](#factory-reset-1)
     - [Trigger reboot](#trigger-reboot-1)
     - [Reload network daemon](#reload-network-daemon)
     - [Status updates](#status-updates)
@@ -771,6 +772,12 @@ omnect-device-service provides a http web service that exposes a web API over a 
 Information about the socket can be found in the appropriate [socket file](systemd/omnect-device-service.socket)<br>
 
 The web service features is disabled by default and must be explicitly activated via environment variable `WEBSERVICE_ENABLED=true`.
+
+### Factory reset
+
+```
+curl -X POST --unix-socket /run/omnect-device-service/api.sock http://localhost/factory-reset/v1
+```
 
 ### Trigger reboot
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ pub mod system;
 pub mod systemd;
 pub mod twin;
 pub mod update_validation;
+pub mod util;
 pub mod web_service;
 
 use azure_iot_sdk::client::*;
@@ -17,13 +18,18 @@ async fn main() {
     log_panics::init();
 
     let mut builder = if cfg!(debug_assertions) {
-        Builder::from_env(Env::default().default_filter_or(concat!(
-            "debug",
-            ",azure_iot_sdk=info",
-            ",reqwest=info",
-            ",hyper_util=info",
-            ",mio=info"
-        )))
+        Builder::from_env(Env::default().default_filter_or(
+            "trace, \
+            actix_server=error, \
+            azure_iot_sdk=info, \
+            eis_utils=info, \
+            hyper=error, \
+            hyper_util=error, \
+            mio=error, \
+            notify=error, \
+            reqwest=error, \
+            tracing=error",
+        ))
     } else {
         Builder::from_env(Env::default().default_filter_or("info"))
     };

--- a/src/systemd/mod.rs
+++ b/src/systemd/mod.rs
@@ -2,9 +2,9 @@ pub mod unit;
 pub mod wait_online;
 pub mod watchdog;
 
-#[cfg(not(feature = "mock"))]
-use anyhow::Context;
 use anyhow::{bail, Result};
+#[cfg(not(feature = "mock"))]
+use log::error;
 use log::{debug, info};
 use sd_notify::NotifyState;
 #[cfg(not(feature = "mock"))]
@@ -25,23 +25,35 @@ pub fn sd_notify_ready() {
 pub async fn reboot() -> Result<()> {
     info!("systemd::reboot");
     //journalctl seems not to have a dbus api
-    let _ = Command::new("sudo")
+    if let Err(e) = Command::new("sudo")
         .arg("journalctl")
         .arg("--sync")
         .status()
-        .context("reboot: failed to execute 'journalctl --sync'")?;
+    {
+        error!("reboot: failed to execute 'journalctl --sync' with: {e}")
+    }
 
-    zbus::Connection::system()
-        .await?
-        .call_method(
-            Some("org.freedesktop.login1"),
-            "/org/freedesktop/login1",
-            Some("org.freedesktop.login1.Manager"),
-            "Reboot",
-            &(true),
+    for i in [0..3] {
+        let result = tokio::time::timeout_at(
+            Instant::now() + Duration::from_secs(3),
+            zbus::Connection::system().await?.call_method(
+                Some("org.freedesktop.login1"),
+                "/org/freedesktop/login1",
+                Some("org.freedesktop.login1.Manager"),
+                "Reboot",
+                &(true),
+            ),
         )
-        .await?;
-    Ok(())
+        .await;
+
+        match result {
+            Err(e) => error!("reboot: trial{i:?} {e}"),
+            Ok(Err(e)) => error!("reboot: trial{i:?} {e}"),
+            _ => return Ok(()),
+        }
+    }
+
+    bail!("reboot: failed")
 }
 
 pub async fn wait_for_system_running(timeout: Duration) -> Result<()> {

--- a/src/systemd/mod.rs
+++ b/src/systemd/mod.rs
@@ -33,6 +33,11 @@ pub async fn reboot() -> Result<()> {
         error!("reboot: failed to execute 'journalctl --sync' with: {e}")
     }
 
+    /*
+       we observed situations when the reboot future never completed.
+       that's why we have here a retry + timeout workaround.
+       the workaround should be removed someday in case we never face the situation again.
+    */
     for i in [0..3] {
         let result = tokio::time::timeout_at(
             Instant::now() + Duration::from_secs(3),

--- a/src/twin/mod.rs
+++ b/src/twin/mod.rs
@@ -455,9 +455,10 @@ impl Twin {
     }
 
     async fn reset_client_with_timeout(&mut self, timeout: Option<time::Duration>) {
-        info!("reset_client: shutdown iotclient");
-        if let Some(client) = self.client.as_mut().take() {
+        if let Some(client) = self.client.as_mut() {
+            info!("reset_client: shutdown iotclient");
             client.shutdown().await;
+            self.client = None;
         }
 
         if let Some(t) = timeout {

--- a/src/twin/mod.rs
+++ b/src/twin/mod.rs
@@ -452,8 +452,7 @@ impl Twin {
 
     async fn reset_client_with_timeout(&mut self, timeout: Option<time::Duration>) {
         info!("reset_client: shutdown iotclient");
-        let client = self.client.as_mut().take();
-        if let Some(client) = client {
+        if let Some(client) = self.client.as_mut().take() {
             client.shutdown().await;
         }
 

--- a/src/twin/mod.rs
+++ b/src/twin/mod.rs
@@ -353,10 +353,8 @@ impl Twin {
     }
 
     async fn handle_direct_method(&mut self, method: DirectMethod) -> Result<()> {
-        info!(
-            "handle_direct_method: {} with payload: {}",
-            method.name, method.payload
-        );
+        let name = method.name.clone();
+        let payload = method.payload.clone();
 
         let result = match method.name.as_str() {
             "factory_reset" => {
@@ -393,8 +391,14 @@ impl Twin {
             _ => Err(anyhow!("direct method unknown")),
         };
 
+        match &result {
+            Ok(Some(result)) => info!("{name}({payload}) succeeded with result: {result}"),
+            Ok(None) => info!("{name}({payload}) succeeded"),
+            Err(e) => error!("{name}({payload}) returned error: {e}"),
+        }
+
         if method.responder.send(result).is_err() {
-            error!("handle_direct_method: receiver dropped");
+            error!("handle_direct_method: {name}({payload}) receiver dropped");
         }
 
         Ok(())

--- a/src/twin/mod.rs
+++ b/src/twin/mod.rs
@@ -327,7 +327,7 @@ impl Twin {
 
         web_service::publish(
             PublishChannel::OnlineStatus,
-            json!({"iothub": self.state == TwinState::Authenticated}),
+            json!({"iothub": auth_status == AuthenticationStatus::Authenticated}),
         )
         .await?;
 

--- a/src/twin/mod.rs
+++ b/src/twin/mod.rs
@@ -456,7 +456,8 @@ impl Twin {
                         .unwrap_or_else(|e| error!("couldn't send while shutting down: {e:#}"));
                 }
 
-                self.reset_client_with_delay(None);
+                client.shutdown().await;
+                self.client = None;
             }
 
             if let Some(ws) = &self.web_service {

--- a/src/twin/mod.rs
+++ b/src/twin/mod.rs
@@ -405,7 +405,7 @@ impl Twin {
     }
 
     async fn handle_webservice_request(&self, request: WebServiceCommand) -> Result<()> {
-        info!("handle_webservice_request: {:?}", request);
+        let req_str = format!("{request:?}");
 
         let (tx_result, result) = match request {
             WebServiceCommand::FactoryReset(reply) => (
@@ -418,6 +418,11 @@ impl Twin {
             WebServiceCommand::Reboot(reply) => (reply, systemd::reboot().await),
             WebServiceCommand::ReloadNetwork(reply) => (reply, system::reload_network().await),
         };
+
+        match &result {
+            Ok(()) => info!("handle_webservice_request: {req_str} succeeded"),
+            Err(e) => error!("handle_webservice_request: {req_str} failed with: {e}"),
+        }
 
         if tx_result.send(result.is_ok()).is_err() {
             error!("handle_webservice_request: receiver dropped");

--- a/src/twin/mod_test.rs
+++ b/src/twin/mod_test.rs
@@ -550,49 +550,37 @@ pub mod mod_test {
         let expect = |_mock: &mut MockMyIotHub| {};
 
         let test = |test_attr: &'_ mut TestConfig| {
-            assert!(block_on(async {
-                test_attr
-                    .twin
-                    .handle_desired(TwinUpdateState::Partial, json!(""))
-                    .await
-            })
-            .is_ok());
+            assert!(test_attr
+                .twin
+                .handle_desired(TwinUpdateState::Partial, json!(""))
+                .is_ok());
 
             assert_eq!(
-                block_on(async {
-                    test_attr
-                        .twin
-                        .handle_desired(TwinUpdateState::Partial, json!({"general_consent": {}}))
-                        .await
-                })
-                .unwrap_err()
-                .to_string(),
+                test_attr
+                    .twin
+                    .handle_desired(TwinUpdateState::Partial, json!({"general_consent": {}}))
+                    .unwrap_err()
+                    .to_string(),
                 "feature disabled: device_update_consent"
             );
 
             assert_eq!(
-                block_on(async {
-                    test_attr
-                        .twin
-                        .handle_desired(TwinUpdateState::Complete, json!(""))
-                        .await
-                })
-                .unwrap_err()
-                .to_string(),
+                test_attr
+                    .twin
+                    .handle_desired(TwinUpdateState::Complete, json!(""))
+                    .unwrap_err()
+                    .to_string(),
                 "handle_desired: 'desired' missing while TwinUpdateState::Complete"
             );
             assert_eq!(
-                block_on(async {
-                    test_attr
-                        .twin
-                        .handle_desired(
-                            TwinUpdateState::Complete,
-                            json!({"desired": {"general_consent": {}}}),
-                        )
-                        .await
-                })
-                .unwrap_err()
-                .to_string(),
+                test_attr
+                    .twin
+                    .handle_desired(
+                        TwinUpdateState::Complete,
+                        json!({"desired": {"general_consent": {}}}),
+                    )
+                    .unwrap_err()
+                    .to_string(),
                 "feature disabled: device_update_consent"
             );
         };
@@ -686,13 +674,10 @@ pub mod mod_test {
                 })
             );
 
-            assert!(block_on(async {
-                test_attr
-                    .twin
-                    .handle_desired(TwinUpdateState::Complete, json!({"desired": {}}))
-                    .await
-            })
-            .is_ok());
+            assert!(test_attr
+                .twin
+                .handle_desired(TwinUpdateState::Complete, json!({"desired": {}}))
+                .is_ok());
 
             assert_json_diff::assert_json_eq!(
                 file_content(),
@@ -702,16 +687,13 @@ pub mod mod_test {
                 })
             );
 
-            assert!(block_on(async {
-                test_attr
-                    .twin
-                    .handle_desired(
-                        TwinUpdateState::Partial,
-                        json!({"general_consent": ["SWUPDATE2", "SWUPDATE1"]}),
-                    )
-                    .await
-            })
-            .is_ok());
+            assert!(test_attr
+                .twin
+                .handle_desired(
+                    TwinUpdateState::Partial,
+                    json!({"general_consent": ["SWUPDATE2", "SWUPDATE1"]}),
+                )
+                .is_ok());
 
             assert_json_diff::assert_json_eq!(
                 file_content(),
@@ -721,13 +703,10 @@ pub mod mod_test {
                 })
             );
 
-            assert!(block_on(async {
-                test_attr
-                    .twin
-                    .handle_desired(TwinUpdateState::Complete, json!({"desired": {}}))
-                    .await
-            })
-            .is_ok());
+            assert!(test_attr
+                .twin
+                .handle_desired(TwinUpdateState::Complete, json!({"desired": {}}))
+                .is_ok());
         };
 
         TestCase::run(test_files, vec![], vec![], expect, test);

--- a/src/twin/mod_test.rs
+++ b/src/twin/mod_test.rs
@@ -36,7 +36,6 @@ pub mod mod_test {
         pub fn build_module_client(&self, _connection_string: &str) -> Result<MockMyIotHub> {
             Ok(MockMyIotHub::default())
         }
-
         pub fn observe_connection_state(
             self,
             _tx_connection_status: AuthenticationObserver,
@@ -204,22 +203,31 @@ pub mod mod_test {
             let (tx_outgoing_message, _rx_outgoing_message) = mpsc::channel(100);
             let (tx_web_service, _rx_web_service) = mpsc::channel(100);
 
+            let mut twin = block_on(Twin::new(
+                tx_web_service,
+                tx_reported_properties,
+                tx_outgoing_message,
+            ))
+            .unwrap();
+
+            let client_builder = IotHubClient::builder()
+                .observe_connection_state(tx_connection_status)
+                .observe_desired_properties(tx_twin_desired)
+                .observe_direct_methods(tx_direct_method);
+            twin.client = Some(
+                client_builder
+                    .build_module_client("connection_string")
+                    .unwrap(),
+            );
+
             // create test config
             let mut config = TestConfig {
-                twin: block_on(Twin::new(
-                    tx_connection_status,
-                    tx_twin_desired,
-                    tx_direct_method,
-                    tx_web_service,
-                    tx_reported_properties,
-                    tx_outgoing_message,
-                ))
-                .unwrap(),
+                twin,
                 dir: PathBuf::from(test_env.dirpath()),
             };
 
             // set testcase specific mock expectaions
-            set_mock_expectations(&mut config.twin.client);
+            set_mock_expectations(&mut config.twin.client.as_mut().unwrap());
 
             // run test
             run_test(&mut config);
@@ -227,7 +235,13 @@ pub mod mod_test {
             // compute reported properties
             while let Ok(val) = rx_reported_properties.try_recv() {
                 info!("{val:?}");
-                config.twin.client.twin_report(val).unwrap()
+                config
+                    .twin
+                    .client
+                    .as_ref()
+                    .unwrap()
+                    .twin_report(val)
+                    .unwrap()
             }
 
             // cleanup env vars

--- a/src/twin/network_status.rs
+++ b/src/twin/network_status.rs
@@ -54,7 +54,8 @@ impl Feature for NetworkStatus {
     ) -> Result<()> {
         self.ensure()?;
         self.tx_reported_properties = Some(tx_reported_properties);
-        self.report().await
+        self.refresh().await?;
+        Ok(())
     }
 }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,27 @@
+use futures::Stream;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::time::{Instant, Interval};
+
+#[derive(Debug)]
+pub struct IntervalStream {
+    inner: Option<Interval>,
+}
+
+impl IntervalStream {
+    pub fn new(interval: Option<Interval>) -> Self {
+        Self { inner: interval }
+    }
+}
+
+impl Stream for IntervalStream {
+    type Item = Instant;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Instant>> {
+        if let Some(i) = self.inner.as_mut() {
+            i.poll_tick(cx).map(Some)
+        } else {
+            Poll::Pending
+        }
+    }
+}

--- a/src/web_service.rs
+++ b/src/web_service.rs
@@ -245,9 +245,13 @@ impl WebService {
     ) -> impl Responder {
         tx_request.send(cmd).await.unwrap();
 
-        match rx_reply.await.unwrap() {
-            true => HttpResponse::Ok().finish(),
-            false => {
+        match rx_reply.await {
+            Ok(true) => HttpResponse::Ok().finish(),
+            Ok(false) => {
+                HttpResponse::build(actix_web::http::StatusCode::INTERNAL_SERVER_ERROR).finish()
+            }
+            Err(_) => {
+                error!("couldn't receive command result");
                 HttpResponse::build(actix_web::http::StatusCode::INTERNAL_SERVER_ERROR).finish()
             }
         }

--- a/systemd/omnect-device-service.service
+++ b/systemd/omnect-device-service.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=omnect-device-service
 # we want time-sync.target but want to start even if it blocks, so we can not use After=aziot-identityd.service time-sync.target
-After=network-online.target systemd-tmpfiles-setup.service omnect-device-service.socket
-Wants=network-online.target systemd-tmpfiles-setup.service aziot-identityd.service time-sync.target
+After=network.target systemd-tmpfiles-setup.service omnect-device-service.socket
+Wants=network.target systemd-tmpfiles-setup.service aziot-identityd.service time-sync.target
 Requires=omnect-device-service.socket
 StartLimitBurst=10
 StartLimitIntervalSec=120


### PR DESCRIPTION
- refactored startup and event loop:
  - call all handlers in `select!` loop in blocking mode:
    - event handlers are processed sequentially 
    - if an event handler blocks too long, the systemd watchdog woudn't be satisfied anymore and omnect-device-service would be killed
  - changed iothub client to be optional. wait asynchronously for iothub client to be created and connected.
  - changed systemd service startup dependency `network-online.target` to `network.target`
  - refactored provisioning client to be able to start even on an un-provisioned and offline device
- refactored reboot: 
  - reboot command via dbus sometimes didn't return. the reason is still unknown.
  - as temporary solution and for better analysis, the command is executed with timeout and retry for the moment
- fixed wrong usage of timer futures: use `pin!` macro to drive the futures instead of calling the whole function again in each `select!` loop.
- fixed bug evaluating online state
- fixed bug when refreshing network status
- added missing docu for factory-reset via web-service