### PR TITLE
fix: fixed desired general consent which now preserves reset_consent_on_fail of consent_conf.json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-device-service"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "actix-server",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-device-service"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-device-service.git"
-version = "0.28.2"
+version = "0.28.3"
 
 [dependencies]
 actix-server = { version = "2.3", default-features = false }


### PR DESCRIPTION
- fixed bug when `reset_consent_on_fail` of `consent_conf.json` was dropped
- fixed test case
- `reset_consent_on_fail` is now reported together with desired general consent