### PR TITLE
feat: replace async-trait by dynosaur

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,6 +1015,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "dynosaur"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "277b2cb52d2df4acece06bb16bc0bb0a006970c7bf504eac2d310927a6f65890"
+dependencies = [
+ "dynosaur_derive",
+ "trait-variant",
+]
+
+[[package]]
+name = "dynosaur_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a4102713839a8c01c77c165bc38ef2e83948f6397fa1e1dcfacec0f07b149d3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "eis-utils"
 version = "0.3.3"
 source = "git+https://github.com/omnect/eis-utils.git?tag=0.3.3#bc4d78ddc33cb136aa242f25d09571e780825a94"
@@ -1131,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
@@ -1742,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
 
 [[package]]
 name = "icu_normalizer"
@@ -1766,9 +1787,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
 
 [[package]]
 name = "icu_properties"
@@ -1787,9 +1808,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_provider"
@@ -2385,17 +2406,17 @@ dependencies = [
 
 [[package]]
 name = "omnect-device-service"
-version = "0.32.1"
+version = "0.32.2"
 dependencies = [
  "actix-server",
  "actix-web",
  "anyhow",
  "assert-json-diff",
- "async-trait",
  "azure-iot-sdk",
  "base64 0.22.1",
  "cp_r",
  "dotenvy",
+ "dynosaur",
  "env_logger",
  "freedesktop_entry_parser",
  "futures",
@@ -2439,9 +2460,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.1"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+checksum = "c2806eaa3524762875e21c3dcd057bc4b7bfa01ce4da8d46be1cd43649e1cc6b"
 
 [[package]]
 name = "openssl"
@@ -3501,6 +3522,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "trait-variant"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,18 +8,18 @@ license = "MIT OR Apache-2.0"
 name = "omnect-device-service"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-device-service.git"
-version = "0.32.1"
+version = "0.32.2"
 
 [dependencies]
 actix-server = { version = "2.3", default-features = false }
 actix-web = { version = "4.9", default-features = false }
 anyhow = { version = "1.0", default-features = false }
-async-trait = { version = "0.1", default-features = false }
 azure-iot-sdk = { git = "https://github.com/omnect/azure-iot-sdk.git", tag = "0.14.0", default-features = false, features = [
   "module_client",
 ] }
 base64 = { version = "0.22", default-features = false }
 dotenvy = { version = "0.15", default-features = false }
+dynosaur = { version = "0.2", default-features = false }
 env_logger = { version = "0.11", default-features = false }
 freedesktop_entry_parser = { version = "1.3", default-features = false }
 futures = { version = "0.3", default-features = false }

--- a/src/twin/consent.rs
+++ b/src/twin/consent.rs
@@ -3,7 +3,6 @@ use crate::{
     twin::{feature::*, Feature},
 };
 use anyhow::{bail, ensure, Context, Result};
-use async_trait::async_trait;
 use azure_iot_sdk::client::IotMessage;
 use log::{info, warn};
 use notify_debouncer_full::{notify::*, Debouncer, NoCache};
@@ -62,7 +61,6 @@ pub struct DeviceUpdateConsent {
     tx_reported_properties: Option<Sender<serde_json::Value>>,
 }
 
-#[async_trait(?Send)]
 impl Feature for DeviceUpdateConsent {
     fn name(&self) -> String {
         Self::ID.to_string()

--- a/src/twin/factory_reset.rs
+++ b/src/twin/factory_reset.rs
@@ -4,7 +4,6 @@ use crate::{
     web_service,
 };
 use anyhow::{bail, Context, Result};
-use async_trait::async_trait;
 use azure_iot_sdk::client::IotMessage;
 use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
@@ -60,7 +59,6 @@ pub struct FactoryReset {
     tx_reported_properties: Option<Sender<serde_json::Value>>,
 }
 
-#[async_trait(?Send)]
 impl Feature for FactoryReset {
     fn name(&self) -> String {
         Self::ID.to_string()

--- a/src/twin/feature/mod.rs
+++ b/src/twin/feature/mod.rs
@@ -3,7 +3,6 @@ use crate::twin::{
     TwinUpdateState,
 };
 use anyhow::{bail, ensure, Result};
-use async_trait::async_trait;
 use azure_iot_sdk::client::{DirectMethod, IotMessage};
 use futures::Stream;
 use futures::StreamExt;
@@ -165,8 +164,8 @@ pub type CommandResult = Result<Option<serde_json::Value>>;
 pub type CommandRequestStream = Pin<Box<dyn Stream<Item = CommandRequest> + Send>>;
 pub type CommandRequestStreamResult = Result<Option<CommandRequestStream>>;
 
-#[async_trait(?Send)]
-pub trait Feature {
+#[dynosaur::dynosaur(pub DynFeature)]
+pub(crate) trait Feature {
     fn name(&self) -> String;
     fn version(&self) -> u8;
     fn is_enabled(&self) -> bool;

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -14,7 +14,6 @@ use crate::{
     },
 };
 use anyhow::{bail, ensure, Context, Result};
-use async_trait::async_trait;
 use base64::{prelude::BASE64_STANDARD, Engine};
 use log::{debug, error, info};
 use serde::Deserialize;
@@ -131,7 +130,6 @@ impl Drop for FirmwareUpdate {
     }
 }
 
-#[async_trait(?Send)]
 impl Feature for FirmwareUpdate {
     fn name(&self) -> String {
         Self::ID.to_string()

--- a/src/twin/mod.rs
+++ b/src/twin/mod.rs
@@ -61,7 +61,7 @@ pub struct Twin {
     tx_outgoing_message: mpsc::Sender<IotMessage>,
     update_validated: bool,
     state: TwinState,
-    features: HashMap<TypeId, Box<dyn Feature>>,
+    features: HashMap<TypeId, Box<DynFeature<'static>>>,
     waiting_for_reboot: bool,
 }
 
@@ -79,48 +79,46 @@ impl Twin {
         let web_service = web_service::WebService::run(tx_command_request.clone()).await?;
         let state = TwinState::Uninitialized;
         let waiting_for_reboot = false;
-
         let features = HashMap::from([
             (
                 TypeId::of::<consent::DeviceUpdateConsent>(),
-                Box::<consent::DeviceUpdateConsent>::default() as Box<dyn Feature>,
+                DynFeature::boxed(consent::DeviceUpdateConsent::default()),
             ),
             (
                 TypeId::of::<factory_reset::FactoryReset>(),
-                Box::new(factory_reset::FactoryReset::new()) as Box<dyn Feature>,
+                DynFeature::boxed(factory_reset::FactoryReset::new()),
             ),
             (
                 TypeId::of::<firmware_update::FirmwareUpdate>(),
-                Box::new(firmware_update::FirmwareUpdate::new(update_validation))
-                    as Box<dyn Feature>,
+                DynFeature::boxed(firmware_update::FirmwareUpdate::new(update_validation)),
             ),
             (
                 TypeId::of::<modem_info::ModemInfo>(),
-                Box::new(modem_info::ModemInfo::new()) as Box<dyn Feature>,
+                DynFeature::boxed(modem_info::ModemInfo::new()),
             ),
             (
                 TypeId::of::<network::Network>(),
-                Box::<network::Network>::default() as Box<dyn Feature>,
+                DynFeature::boxed(network::Network::default()),
             ),
             (
                 TypeId::of::<provisioning_config::ProvisioningConfig>(),
-                Box::new(provisioning_config::ProvisioningConfig::new()?) as Box<dyn Feature>,
+                DynFeature::boxed(provisioning_config::ProvisioningConfig::new()?),
             ),
             (
                 TypeId::of::<reboot::Reboot>(),
-                Box::<reboot::Reboot>::default() as Box<dyn Feature>,
+                DynFeature::boxed(reboot::Reboot::default()),
             ),
             (
                 TypeId::of::<ssh_tunnel::SshTunnel>(),
-                Box::new(ssh_tunnel::SshTunnel::new()) as Box<dyn Feature>,
+                DynFeature::boxed(ssh_tunnel::SshTunnel::new()),
             ),
             (
                 TypeId::of::<system_info::SystemInfo>(),
-                Box::new(system_info::SystemInfo::new()?) as Box<dyn Feature>,
+                DynFeature::boxed(system_info::SystemInfo::new()?),
             ),
             (
                 TypeId::of::<wifi_commissioning::WifiCommissioning>(),
-                Box::<wifi_commissioning::WifiCommissioning>::default() as Box<dyn Feature>,
+                DynFeature::boxed(wifi_commissioning::WifiCommissioning::default()),
             ),
         ]);
 

--- a/src/twin/modem_info.rs
+++ b/src/twin/modem_info.rs
@@ -1,6 +1,5 @@
 use super::{feature::*, Feature};
 use anyhow::{bail, Context, Result};
-use async_trait::async_trait;
 use azure_iot_sdk::client::IotMessage;
 use lazy_static::lazy_static;
 use serde_json::json;
@@ -341,7 +340,6 @@ lazy_static! {
     };
 }
 
-#[async_trait(?Send)]
 impl Feature for ModemInfo {
     fn name(&self) -> String {
         ID.to_string()

--- a/src/twin/network.rs
+++ b/src/twin/network.rs
@@ -4,7 +4,6 @@ use crate::{
     web_service,
 };
 use anyhow::{bail, Context, Result};
-use async_trait::async_trait;
 use azure_iot_sdk::client::IotMessage;
 use lazy_static::lazy_static;
 use log::{debug, error, info, warn};
@@ -54,7 +53,6 @@ pub struct Network {
     interfaces: Vec<Interface>,
 }
 
-#[async_trait(?Send)]
 impl Feature for Network {
     fn name(&self) -> String {
         Self::ID.to_string()

--- a/src/twin/provisioning_config.rs
+++ b/src/twin/provisioning_config.rs
@@ -1,6 +1,5 @@
 use crate::twin::{feature::*, Feature};
 use anyhow::{bail, ensure, Context, Result};
-use async_trait::async_trait;
 use azure_iot_sdk::client::IotMessage;
 use lazy_static::lazy_static;
 use log::{debug, info, warn};
@@ -120,7 +119,6 @@ pub struct ProvisioningConfig {
     hostname: String,
 }
 
-#[async_trait(?Send)]
 impl Feature for ProvisioningConfig {
     fn name(&self) -> String {
         Self::ID.to_string()

--- a/src/twin/reboot.rs
+++ b/src/twin/reboot.rs
@@ -4,7 +4,6 @@ use crate::{
     web_service,
 };
 use anyhow::{bail, Context, Result};
-use async_trait::async_trait;
 use azure_iot_sdk::client::IotMessage;
 use log::{debug, error, info};
 use serde::Deserialize;
@@ -22,7 +21,6 @@ pub struct Reboot {
     tx_reported_properties: Option<Sender<serde_json::Value>>,
 }
 
-#[async_trait(?Send)]
 impl Feature for Reboot {
     fn name(&self) -> String {
         Self::ID.to_string()

--- a/src/twin/ssh_tunnel.rs
+++ b/src/twin/ssh_tunnel.rs
@@ -3,7 +3,6 @@ use crate::twin::{
     Feature,
 };
 use anyhow::{bail, ensure, Context, Result};
-use async_trait::async_trait;
 use azure_iot_sdk::client::IotMessage;
 use log::{debug, error, info, warn};
 use serde::{de::Error, Deserialize, Deserializer};
@@ -127,7 +126,6 @@ pub struct SshTunnel {
     ssh_tunnel_semaphore: Arc<Semaphore>,
 }
 
-#[async_trait(?Send)]
 impl Feature for SshTunnel {
     fn name(&self) -> String {
         Self::ID.to_string()

--- a/src/twin/system_info.rs
+++ b/src/twin/system_info.rs
@@ -3,7 +3,6 @@ use crate::{
     web_service,
 };
 use anyhow::{bail, Context, Result};
-use async_trait::async_trait;
 use azure_iot_sdk::client::{IotHubClient, IotMessage};
 use futures::StreamExt;
 use lazy_static::lazy_static;
@@ -184,8 +183,6 @@ pub struct SystemInfo {
     software_info: SoftwareInfo,
     hardware_info: HardwareInfo,
 }
-
-#[async_trait(?Send)]
 impl Feature for SystemInfo {
     fn name(&self) -> String {
         Self::ID.to_string()


### PR DESCRIPTION
Since Rust 1.74 async in traits is supported. Together with [dynosaur](https://docs.rs/dynosaur/latest/dynosaur/) we can make use of this and get rid of async-trait.