### PR TITLE
fix: issue with high CPU load on SSH tunnel open

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2389,7 +2389,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-device-service"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "actix-server",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-device-service"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-device-service.git"
-version = "0.30.4"
+version = "0.30.5"
 
 [dependencies]
 actix-server = { version = "2.3", default-features = false }

--- a/src/bootloader_env/grub.rs
+++ b/src/bootloader_env/grub.rs
@@ -20,8 +20,8 @@ pub fn bootloader_env(key: &str) -> Result<String> {
         let mut j = i.split('=');
         if j.next().context("failed to split grub-editenv line")? == key {
             value = j
-                .last()
-                .context("failed to get {key}'s value")?
+                .next_back()
+                .context(format!("failed to get {key}'s value"))?
                 .trim()
                 .to_string();
             break;
@@ -36,7 +36,7 @@ pub fn set_bootloader_env(key: &str, value: &str) -> Result<()> {
         Command::new("sudo")
             .args(["grub-editenv", GRUB_ENV_FILE, "set", set.as_str()])
             .status()
-            .context("failed to call \"sudo grub-editenv set {set}\"")?
+            .context(format!("failed to call \"sudo grub-editenv set {set}\""))?
             .success(),
         "\"sudo grub-editenv set {set}\" failed"
     );
@@ -49,7 +49,7 @@ pub fn unset_bootloader_env(key: &str) -> Result<()> {
         Command::new("sudo")
             .args(["grub-editenv", GRUB_ENV_FILE, "unset", key])
             .status()
-            .context("failed to call \"sudo grub-editenv unset {key}\"")?
+            .context(format!("failed to call \"sudo grub-editenv unset {key}\""))?
             .success(),
         "\"sudo grub-editenv unset {key}\" failed"
     );

--- a/src/bootloader_env/uboot.rs
+++ b/src/bootloader_env/uboot.rs
@@ -9,8 +9,8 @@ pub fn bootloader_env(key: &str) -> Result<String> {
     let value = String::from_utf8(value.stdout)?;
     let mut value = value
         .split('=')
-        .last()
-        .context("failed to get {key}'s value")?
+        .next_back()
+        .context(format!("failed to get {key}'s value"))?
         .trim()
         .to_string();
     let len = value.trim_end_matches(&['\r', '\n'][..]).len();
@@ -24,7 +24,7 @@ pub fn set_bootloader_env(key: &str, value: &str) -> Result<()> {
         Command::new("sudo")
             .args(["fw_setenv", key, value])
             .status()
-            .context("failed to execute 'fw_setenv {key} {value}'")?
+            .context(format!("failed to execute 'fw_setenv {key} {value}'"))?
             .success(),
         "\"fw_setenv {key} {value}\" failed"
     );
@@ -37,7 +37,7 @@ pub fn unset_bootloader_env(key: &str) -> Result<()> {
         Command::new("sudo")
             .args(["fw_setenv", key])
             .status()
-            .context("failed to execute \"fw_setenv {key}\"")?
+            .context(format!("failed to execute \"fw_setenv {key}\""))?
             .success(),
         "\"fw_setenv {key}\" failed"
     );


### PR DESCRIPTION
There was an issue with ssh causing a high CPU utilization upon creating the SSH tunnel. The issue laid within the way ssh polls its file descriptors: in the omnect-device-service we would wait for an initial message that the ssh tunnel has been successfully created and then implicitly drop and thus close the pipe to the ssh process. The ssh process, on the other side, polls on its FDs for events, most notably in this case stdout. The closed pipe would then cause this poll to always directly fail with a POLLERR, thus causing ssh to poll at a high frequency.

With this PR we take care to keep the pipe open until the ssh process terminates.

Further changes (lint):
- broken format strings
- improved iterator access