### PR TITLE
fix: unit tests failed at reboot_reason() invocation

### DIFF
--- a/src/reboot_reason.rs
+++ b/src/reboot_reason.rs
@@ -20,6 +20,8 @@ pub fn reboot_reason(reason: &str, extra_info: &str) -> Result<()> {
 	cmd.args([ REBOOT_REASON_SCRIPT ]);
     } else if cfg!(feature = "bootloader_uboot") {
 	cmd = Command::new(REBOOT_REASON_SCRIPT);
+    } else if cfg!(feature = "mock") {
+	return Ok(());
     } else {
 	unreachable!()
     };


### PR DESCRIPTION
Unit tests are invoked with neither feature, 'bootloader_grub' or 'bootloader_uboot', which is considered an error on the device.

So, to circumvent test failures allow returning Ok() when feature 'mock' is set.