### PR TITLE
fix(omnect-device-service): added mocked version of reboot_reason()

### DIFF
--- a/src/reboot_reason.rs
+++ b/src/reboot_reason.rs
@@ -6,10 +6,10 @@ use anyhow::{Result};
 //   repetetive use of cfg macro is ugly, yes, but having a separate reboot
 //   reason file for mocking purposes is also not ideal
 #[cfg(not(feature = "mock"))]
-use anyhow::{ensure, Context};
-
-#[cfg(not(feature = "mock"))]
-use std::process::Command;
+use {
+    anyhow::{ensure, Context},
+    std::process::Command,
+};
 
 #[cfg(not(feature = "mock"))]
 static REBOOT_REASON_SCRIPT: &str = "/usr/sbin/omnect_reboot_reason.sh";

--- a/src/reboot_reason.rs
+++ b/src/reboot_reason.rs
@@ -1,15 +1,25 @@
 // reboot reason handling
 
-use anyhow::{ensure, Context, Result};
+use anyhow::{Result};
+
+// NOTE:
+//   repetetive use of cfg macro is ugly, yes, but having a separate reboot
+//   reason file for mocking purposes is also not ideal
+#[cfg(not(feature = "mock"))]
+use anyhow::{ensure, Context};
+
+#[cfg(not(feature = "mock"))]
 use std::process::Command;
 
+#[cfg(not(feature = "mock"))]
 static REBOOT_REASON_SCRIPT: &str = "/usr/sbin/omnect_reboot_reason.sh";
 
+#[cfg(not(feature = "mock"))]
 pub fn reboot_reason(reason: &str, extra_info: &str) -> Result<()> {
     // make arguments shell script proof
     let reboot_reason_cmd = "log";
-    let reason = format!("{reason_str}", reason_str = reason.replace("\"", "'"));
-    let extra_info = format!("{extra_info_str}", extra_info_str = extra_info.replace("\"", "'"));
+    let reason = reason.replace("\"", "'").to_string();
+    let extra_info = extra_info.replace("\"", "'").to_string();
 
     let common_args = [reboot_reason_cmd, &reason, &extra_info];
     let mut cmd: Command;
@@ -20,8 +30,6 @@ pub fn reboot_reason(reason: &str, extra_info: &str) -> Result<()> {
 	cmd.args([ REBOOT_REASON_SCRIPT ]);
     } else if cfg!(feature = "bootloader_uboot") {
 	cmd = Command::new(REBOOT_REASON_SCRIPT);
-    } else if cfg!(feature = "mock") {
-	return Ok(());
     } else {
 	unreachable!()
     };
@@ -33,5 +41,10 @@ pub fn reboot_reason(reason: &str, extra_info: &str) -> Result<()> {
         "'{REBOOT_REASON_SCRIPT} {reason} \"{extra_info}\"' failed"
     );
 
+    Ok(())
+}
+
+#[cfg(feature = "mock")]
+pub fn reboot_reason(_reason: &str, _extra_info: &str) -> Result<()> {
     Ok(())
 }


### PR DESCRIPTION
Additionally, follow clippy advices concerning useless use of format macro.

Signed-off-by: Harry Waschkeit <44188360+HarryWaschkeit@users.noreply.github.com>