### PR TITLE
feat: factory reset v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1367,8 +1367,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1617,7 +1619,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "openssl-sys",
- "parking_lot",
+ "parking_lot 0.12.3",
  "tokio",
  "tokio-openssl",
  "tower-layer",
@@ -1907,6 +1909,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1949,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.0.8"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+checksum = "8cf0c5a3f977f1cebd92cf05ebb14e1c941c642fb57c9a7d4302455b33ba326f"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -2003,7 +2017,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.12",
 ]
 
 [[package]]
@@ -2429,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-device-service"
-version = "0.40.6"
+version = "0.41.0"
 dependencies = [
  "actix-server",
  "actix-web",
@@ -2459,6 +2473,8 @@ dependencies = [
  "regex",
  "regex-lite",
  "reqwest",
+ "reqwest-middleware",
+ "reqwest-retry",
  "sd-notify",
  "serde",
  "serde_json",
@@ -2549,12 +2565,37 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.10",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -2565,7 +2606,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.12",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -2765,6 +2806,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
@@ -2845,6 +2895,51 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-registry",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.3.1",
+ "reqwest",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c73e4195a6bfbcb174b790d9b3407ab90646976c55de58a6515da25d851178"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "getrandom 0.2.16",
+ "http 1.3.1",
+ "hyper 1.6.0",
+ "parking_lot 0.11.2",
+ "reqwest",
+ "reqwest-middleware",
+ "retry-policies",
+ "thiserror 1.0.69",
+ "tokio",
+ "wasm-timer",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
+dependencies = [
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -3381,15 +3476,15 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "parking_lot",
+ "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -3738,6 +3833,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-device-service"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-device-service.git"
-version = "0.40.6"
+version = "0.41.0"
 
 [dependencies]
 actix-server = { version = "2.3", default-features = false }
@@ -36,6 +36,8 @@ regex-lite = { version = "0.1", default-features = true }
 reqwest = { version = "0.12", default-features = false, features = [
   "default-tls",
 ] }
+reqwest-middleware = { version = "0.4", default-features = false }
+reqwest-retry = { version = "0.7", default-features = false }
 sd-notify = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -4,57 +4,59 @@ Product page: <www.omnect.io>
 
 This module serves as interface between omnect cloud and device to support certain end to end workflows:
 
-- [omnect-device-service](#omnect-device-service)
-  - [Configuration](#configuration)
-    - [Log level](#log-level)
-    - [azure-iot-sdk](#azure-iot-sdk)
-  - [Azure twin features](#azure-twin-features)
-    - [System Info](#system-info)
+  * [Configuration](#configuration)
+    + [Log level](#log-level)
+    + [azure-iot-sdk](#azure-iot-sdk)
+  * [Azure twin features](#azure-twin-features)
+    + [System Info](#system-info)
       - [Feature availability](#feature-availability)
       - [Current reported system info](#current-reported-system-info)
       - [Current reported device metrics](#current-reported-device-metrics)
-    - [Factory reset](#factory-reset)
+    + [Factory reset](#factory-reset)
       - [Feature availability](#feature-availability-1)
+      - [Supported preserve keys](#supported-preserve-keys)
       - [Trigger factory reset](#trigger-factory-reset)
-      - [Report factory reset status](#report-factory-reset-status)
-    - [iot-hub-device-update user consent](#iot-hub-device-update-user-consent)
+      - [Report factory reset result](#report-factory-reset-result)
+    + [iot-hub-device-update user consent](#iot-hub-device-update-user-consent)
       - [Feature availability](#feature-availability-2)
       - [Configure current desired general consent](#configure-current-desired-general-consent)
       - [Grant user consent](#grant-user-consent)
       - [Current reported user consent status](#current-reported-user-consent-status)
-    - [provisioning configuration](#provisioning-configuration)
+    + [provisioning configuration](#provisioning-configuration)
       - [Feature availability](#feature-availability-3)
       - [Current reported provisioning configuration](#current-reported-provisioning-configuration)
-    - [Reboot](#reboot)
+    + [Reboot](#reboot)
       - [Feature availability](#feature-availability-4)
       - [Trigger reboot](#trigger-reboot)
       - [Configure wait-online reboot timeout](#configure-wait-online-reboot-timeout)
-    - [Modem Info](#modem-info)
+    + [Modem Info](#modem-info)
       - [Feature availability](#feature-availability-5)
       - [Current reported modem info](#current-reported-modem-info)
-    - [Network status](#network-status)
+    + [Network status](#network-status)
       - [Feature availability](#feature-availability-6)
       - [Current reported network status](#current-reported-network-status)
-    - [SSH Tunnel handling](#ssh-tunnel-handling)
+    + [SSH Tunnel handling](#ssh-tunnel-handling)
       - [Feature availability](#feature-availability-7)
       - [Current reported ssh tunnel feature status](#current-reported-ssh-tunnel-feature-status)
       - [Configure the ssh certificate](#configure-the-ssh-certificate)
       - [Access to Device SSH Public Key](#access-to-device-ssh-public-key)
       - [Opening the SSH tunnel](#opening-the-ssh-tunnel)
       - [Closing the SSH tunnel](#closing-the-ssh-tunnel)
-    - [Wifi commissioning service](#wifi-commissioning-service)
+    + [Wifi commissioning service](#wifi-commissioning-service)
       - [Feature availability](#feature-availability-8)
-  - [Local web service](#local-web-service)
-    - [Factory reset](#factory-reset-1)
-    - [Local firmware update](#local-firmware-update)
-    - [Trigger reboot](#trigger-reboot-1)
-    - [Reload network daemon](#reload-network-daemon)
-    - [Status updates](#status-updates)
+  * [Local web service](#local-web-service)
+    + [Factory reset](#factory-reset-1)
+    + [Local firmware update](#local-firmware-update)
+      - [Load a firmware package](#load-a-firmware-package)
+      - [Run installation of a loaded firmware package](#run-installation-of-a-loaded-firmware-package)
+    + [Trigger reboot](#trigger-reboot-1)
+    + [Reload network daemon](#reload-network-daemon)
+    + [Status updates](#status-updates)
       - [Publish status](#publish-status)
       - [Republish status](#republish-status)
       - [Get status](#get-status)
-  - [Update validation](#update-validation)
-    - [Criteria for a successful update](#criteria-for-a-successful-update)
+  * [Update validation](#update-validation)
+    + [Criteria for a successful update](#criteria-for-a-successful-update)
 - [License](#license)
 - [Contribution](#contribution)
 
@@ -196,6 +198,7 @@ Example of the D2C payload:
 
 The module itself does not perform a factory reset.
 It serves as an interface between the cloud and the built-in factory reset from the [omnect yocto image](https://github.com/omnect/meta-omnect).
+Read the [documentation](https://github.com/omnect/meta-omnect#factory-reset) in order to understand the concepts.
 
 #### Feature availability
 
@@ -214,6 +217,17 @@ The availability of the feature might be suppressed by creating the following en
 SUPPRESS_FACTORY_RESET=true
 ```
 
+#### Supported preserve keys
+
+Available preserve keys are reported as follows:
+
+```
+"factory_reset":
+{
+  "keys": ["network", "firewall", "certificates", "applications"]
+}
+```
+
 #### Trigger factory reset
 
 **Direct method: factory reset**
@@ -225,10 +239,7 @@ Payload:
 ```
 {
   "mode": <factory reset mode number>,
-  "preserve":
-  [
-      "network", "firewall", "certificates", "applications"
-  ]
+  "preserve": ["network", "firewall", "certificates", "applications"]
 }
 ```
 
@@ -260,27 +271,23 @@ In all other cases there will be an error status and a meaningful message in the
 }
 ```
 
-#### Report factory reset status
+#### Report factory reset result
 
-Performing a factory reset also triggers a device restart. The restart time of a device depends on the selected factory reset. After the device has been restarted, this module sends a confirmation to the cloud as reported property in the module twin.
+Performing a factory reset also triggers a device restart. The restart duration might depend on the selected factory reset mode. After the device has been restarted, the result is reported in the module twin.
+Details about the result format can be found [here](https://github.com/omnect/meta-omnect#factory-reset).
 
 ```
 "factory_reset":
 {
-  "status":
-  {
-      "date": "<UTC time of the factory reset status>",
-      "status": "<status>"
+  "result": {
+      "error": "0",
+      "paths": [
+          "/etc/omnect/factory-reset.d/"
+      ],
+      "status": 0
   }
 }
 ```
-
-The following status information is defined:
-
-- "in_progress"
-- "succeeded"
-- "failed"
-- "unexpected factory reset type"
 
 ### iot-hub-device-update user consent
 

--- a/src/twin/factory_reset.rs
+++ b/src/twin/factory_reset.rs
@@ -7,12 +7,11 @@ use crate::{
 };
 use anyhow::{bail, Context, Result};
 use azure_iot_sdk::client::IotMessage;
-use log::{debug, error, info, warn};
+use log::{debug, error, info};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_repr::*;
 use std::{collections::HashMap, env, fs::read_dir};
-use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tokio::sync::mpsc::Sender;
 
 macro_rules! factory_reset_status_path {
@@ -57,8 +56,34 @@ pub struct FactoryResetCommand {
     pub preserve: Vec<String>,
 }
 
+#[derive(Debug, Deserialize_repr, PartialEq, Serialize_repr)]
+#[repr(u8)]
+pub enum FactoryResetStatus {
+    ModeSupported = 0,
+    ModeUnsupported = 1,
+    BackupRestoreError = 2,
+    ConfigurationError = 3,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+struct FactoryResetResult {
+    status: FactoryResetStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    context: Option<String>,
+    error: String,
+    paths: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+struct FactoryResetReport {
+    keys: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<FactoryResetResult>,
+}
+
 pub struct FactoryReset {
     tx_reported_properties: Option<Sender<serde_json::Value>>,
+    report: FactoryResetReport,
 }
 
 impl Feature for FactoryReset {
@@ -75,8 +100,14 @@ impl Feature for FactoryReset {
     }
 
     async fn connect_web_service(&self) -> Result<()> {
-        self.report_factory_reset_keys().await?;
-        self.handle_factory_reset_status().await
+        web_service::publish(
+            web_service::PublishChannel::FactoryResetV1,
+            serde_json::to_value(&self.report)
+                .context("connect_web_service: failed to serialize")?,
+        )
+        .await;
+
+        Ok(())
     }
 
     async fn connect_twin(
@@ -84,9 +115,16 @@ impl Feature for FactoryReset {
         tx_reported_properties: Sender<serde_json::Value>,
         _tx_outgoing_message: Sender<IotMessage>,
     ) -> Result<()> {
+        tx_reported_properties
+            .send(json!({
+                "factory_reset": &self.report
+            }))
+            .await
+            .context("report_factory_reset_status: send")?;
+
         self.tx_reported_properties = Some(tx_reported_properties);
-        self.report_factory_reset_keys().await?;
-        self.handle_factory_reset_status().await
+
+        Ok(())
     }
 
     async fn command(&mut self, cmd: &Command) -> CommandResult {
@@ -103,13 +141,19 @@ impl Feature for FactoryReset {
 }
 
 impl FactoryReset {
-    const FACTORY_RESET_VERSION: u8 = 2;
+    const FACTORY_RESET_VERSION: u8 = 3;
     const ID: &'static str = "factory_reset";
 
-    pub fn new() -> Self {
-        FactoryReset {
+    pub fn new() -> Result<Self> {
+        let report = FactoryResetReport {
+            keys: FactoryReset::factory_reset_keys()?,
+            result: FactoryReset::factory_reset_result()?,
+        };
+
+        Ok(FactoryReset {
             tx_reported_properties: None,
-        }
+            report,
+        })
     }
 
     fn factory_reset_keys() -> Result<Vec<String>> {
@@ -131,27 +175,21 @@ impl FactoryReset {
         Ok(keys)
     }
 
-    async fn report_factory_reset_keys(&self) -> Result<()> {
-        // get keys on each call, since factory_reset.d could have changes
-        let keys = FactoryReset::factory_reset_keys()?;
-        web_service::publish(
-            web_service::PublishChannel::FactoryResetKeysV1,
-            json!({"keys": keys}),
-        )
-        .await;
+    fn factory_reset_result() -> Result<Option<FactoryResetResult>> {
+        let omnect_os_initramfs_json: serde_json::Value =
+            from_json_file(&factory_reset_status_path!())?;
 
-        let Some(tx) = &self.tx_reported_properties else {
-            warn!("report_factory_reset_keys: skip since tx_reported_properties is None");
-            return Ok(());
-        };
+        if omnect_os_initramfs_json["factory-reset"].is_null() {
+            debug!("factory reset: no result");
+            return Ok(None);
+        }
 
-        tx.send(json!({
-            "factory_reset": {
-                "keys": keys,
-            }
-        }))
-        .await
-        .context("report_factory_reset_status: send")
+        let result = serde_json::from_value(omnect_os_initramfs_json["factory-reset"].clone())
+            .context("failed to parse factory reset result from initramfs")?;
+
+        info!("factory reset result: {result:#?}");
+
+        Ok(Some(result))
     }
 
     async fn reset_to_factory_settings(&self, cmd: &FactoryResetCommand) -> CommandResult {
@@ -164,7 +202,7 @@ impl FactoryReset {
         }
 
         bootloader_env::set("factory-reset", &serde_json::to_string(&cmd)?)?;
-        self.report_factory_reset_status("in_progress").await?;
+
         if let Err(e) =
             reboot_reason::write_reboot_reason("factory-reset", "initiated by portal or API")
         {
@@ -173,107 +211,33 @@ impl FactoryReset {
         systemd::reboot().await?;
         Ok(None)
     }
-
-    async fn report_factory_reset_status(&self, status: &str) -> Result<()> {
-        // ToDo why is that not the same format as for the cloud?
-        web_service::publish(
-            web_service::PublishChannel::FactoryResetStatusV1,
-            json!({"factory_reset_status": status}),
-        )
-        .await;
-
-        let Some(tx) = &self.tx_reported_properties else {
-            warn!("report_factory_reset_status: skip since tx_reported_properties is None");
-            return Ok(());
-        };
-
-        tx.send(json!({
-            "factory_reset": {
-                "status": {
-                    "status": status,
-                    "date": OffsetDateTime::now_utc().format(&Rfc3339)
-                    .context("report_factory_reset_status: format time to Rfc3339")?,
-                }
-            }
-        }))
-        .await
-        .context("report_factory_reset_status: send")
-    }
-
-    fn factory_reset_status() -> Result<Option<&'static str>> {
-        let omnect_os_initramfs_json: serde_json::Value =
-            from_json_file(factory_reset_status_path!())?;
-
-        let factory_reset = &omnect_os_initramfs_json["factory-reset"];
-        anyhow::ensure!(factory_reset.is_object(), "factory-reset is not an object");
-
-        let mut factory_reset_status = String::from("");
-        let status = &factory_reset["status"];
-        let error = &factory_reset["error"];
-        if !status.is_null() {
-            factory_reset_status = format!(
-                "{}:{}",
-                status.to_string().trim_matches('"'),
-                error.to_string().trim_matches('"')
-            );
-        }
-
-        debug!("factory_reset_status: {factory_reset_status}");
-        // ToDo more stati
-        match factory_reset_status.as_str() {
-            "0:0" => Ok(Some("succeeded")),
-            "1:-" => bail!("unexpected factory reset type"),
-            "2:-" => bail!("unexpected restore setting"),
-            "" => Ok(None),
-            _ => bail!("unexpected factory reset status format"),
-        }
-    }
-
-    async fn handle_factory_reset_status(&self) -> Result<()> {
-        match Self::factory_reset_status() {
-            Ok(Some(status)) => {
-                info!("factory reset status: {status}");
-                self.report_factory_reset_status(status).await
-            }
-            Ok(None) => {
-                info!("factory reset status: normal boot without factory reset");
-                Ok(())
-            }
-            Err(e) => {
-                warn!("factory reset status: {e:#}");
-                self.report_factory_reset_status(e.to_string().as_str())
-                    .await
-            }
-        }
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use regex::Regex;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn factory_reset_test() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let file_path = temp_dir.path().join("factory-reset.json");
+        let config_file_path = temp_dir.path().join("factory-reset.json");
         let custom_dir_path = temp_dir.path().join("factory-reset.d");
 
         std::fs::copy(
             "testfiles/positive/factory-reset.json",
-            file_path.clone().as_path(),
+            config_file_path.clone().as_path(),
         )
         .unwrap();
         std::fs::create_dir_all(custom_dir_path.clone()).unwrap();
 
-        std::env::set_var("FACTORY_RESET_CONFIG_FILE_PATH", file_path.clone());
+        std::env::set_var(
+            "FACTORY_RESET_STATUS_FILE_PATH",
+            "testfiles/positive/factory-reset-status_succeeded",
+        );
+        std::env::set_var("FACTORY_RESET_CONFIG_FILE_PATH", config_file_path.clone());
         std::env::set_var("FACTORY_RESET_CUSTOM_CONFIG_DIR_PATH", custom_dir_path);
 
-        let (tx_reported_properties, mut rx_reported_properties) = tokio::sync::mpsc::channel(100);
-
-        let mut factory_reset = FactoryReset {
-            tx_reported_properties: Some(tx_reported_properties),
-        };
+        let mut factory_reset = FactoryReset::new().unwrap();
 
         assert!(factory_reset
             .command(&Command::FactoryReset(FactoryResetCommand {
@@ -299,18 +263,28 @@ mod tests {
             .await
             .unwrap();
 
-        let reported = format!("{:?}", rx_reported_properties.recv().await.unwrap());
-        const UTC_REGEX: &str = r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[\+-]\d{2}:\d{2})";
+        let (tx_reported_properties, mut rx_reported_properties) = tokio::sync::mpsc::channel(100);
+        let (tx_outgoing_message, mut _rx_outgoing_message) = tokio::sync::mpsc::channel(100);
 
-        let re = format!(
-            "{}{}{}",
-            regex::escape(r#"Object {"factory_reset": Object {"status": Object {"date": String(""#,),
-            UTC_REGEX,
-            regex::escape(r#""), "status": String("in_progress")}}}"#,),
+        factory_reset
+            .connect_twin(tx_reported_properties, tx_outgoing_message)
+            .await
+            .unwrap();
+
+        let reported: FactoryResetResult = serde_json::from_value(
+            rx_reported_properties.recv().await.unwrap()["factory_reset"]["result"].clone(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            reported,
+            FactoryResetResult {
+                status: FactoryResetStatus::ModeSupported,
+                error: "-".to_string(),
+                context: None,
+                paths: vec![],
+            }
         );
-
-        let re = Regex::new(re.as_str()).unwrap();
-        assert!(re.is_match(&reported));
     }
 
     #[test]
@@ -349,51 +323,38 @@ mod tests {
     #[test]
     fn factory_reset_status_test() {
         std::env::set_var("FACTORY_RESET_STATUS_FILE_PATH", "");
-        assert!(FactoryReset::factory_reset_status()
+        assert!(FactoryReset::factory_reset_result()
             .unwrap_err()
             .to_string()
-            .starts_with("failed to open for read: "));
-
-        std::env::set_var(
-            "FACTORY_RESET_STATUS_FILE_PATH",
-            "testfiles/negative/factory-reset-status_unexpected_reset_type",
-        );
-        assert!(FactoryReset::factory_reset_status()
-            .unwrap_err()
-            .to_string()
-            .starts_with("unexpected factory reset type"));
-
-        std::env::set_var(
-            "FACTORY_RESET_STATUS_FILE_PATH",
-            "testfiles/negative/factory-reset-status_unexpected_reset_settings",
-        );
-        assert!(FactoryReset::factory_reset_status()
-            .unwrap_err()
-            .to_string()
-            .starts_with("unexpected restore setting"));
+            .starts_with("failed to open for read"));
 
         std::env::set_var(
             "FACTORY_RESET_STATUS_FILE_PATH",
             "testfiles/negative/factory-reset-status_unexpected_factory_reset_format",
         );
-        assert!(FactoryReset::factory_reset_status()
+        assert!(FactoryReset::factory_reset_result()
             .unwrap_err()
             .to_string()
-            .starts_with("unexpected factory reset status format"));
+            .starts_with("failed to parse factory reset result from initramfs"));
 
         std::env::set_var(
             "FACTORY_RESET_STATUS_FILE_PATH",
             "testfiles/positive/factory-reset-status_succeeded",
         );
         assert_eq!(
-            FactoryReset::factory_reset_status().unwrap().unwrap(),
-            "succeeded"
+            FactoryReset::factory_reset_result().unwrap().unwrap(),
+            FactoryResetResult {
+                status: FactoryResetStatus::ModeSupported,
+                error: "-".to_string(),
+                paths: vec![],
+                context: None,
+            }
         );
 
         std::env::set_var(
             "FACTORY_RESET_STATUS_FILE_PATH",
             "testfiles/positive/factory-reset-status_normal_boot",
         );
-        assert!(FactoryReset::factory_reset_status().unwrap().is_none());
+        assert!(FactoryReset::factory_reset_result().unwrap().is_none());
     }
 }

--- a/src/twin/factory_reset.rs
+++ b/src/twin/factory_reset.rs
@@ -120,7 +120,7 @@ impl Feature for FactoryReset {
                 "factory_reset": &self.report
             }))
             .await
-            .context("report_factory_reset_status: send")?;
+            .context("connect_twin: send")?;
 
         self.tx_reported_properties = Some(tx_reported_properties);
 

--- a/src/twin/reboot.rs
+++ b/src/twin/reboot.rs
@@ -67,7 +67,7 @@ impl Reboot {
         if let Err(e) =
             reboot_reason::write_reboot_reason("ods-reboot", "initiated by portal or API")
         {
-            error!(": failed to write reboot reason [{e}]");
+            error!("reboot: failed to write reboot reason [{e:#}]");
         }
 
         systemd::reboot().await?;

--- a/testfiles/negative/factory-reset-status_unexpected_reset_settings
+++ b/testfiles/negative/factory-reset-status_unexpected_reset_settings
@@ -1,6 +1,0 @@
-{
-    "factory-reset": {
-        "status": "2",
-        "error": "-"
-    }
-}

--- a/testfiles/negative/factory-reset-status_unexpected_reset_type
+++ b/testfiles/negative/factory-reset-status_unexpected_reset_type
@@ -1,6 +1,0 @@
-{
-    "factory-reset": {
-        "status": 1,
-        "error": "-"
-    }
-}

--- a/testfiles/positive/factory-reset-status_normal_boot
+++ b/testfiles/positive/factory-reset-status_normal_boot
@@ -1,3 +1,3 @@
 {
-    "factory-reset": {}
+    "factory-reset": null
 }

--- a/testfiles/positive/factory-reset-status_succeeded
+++ b/testfiles/positive/factory-reset-status_succeeded
@@ -1,6 +1,7 @@
 {
     "factory-reset": {
         "status": 0,
-        "error": 0
+        "error": "-",
+        "paths": []
     }
 }


### PR DESCRIPTION
- factory reset:
  - validate factory reset result from initramfs
  - in case a factory reset happened, report the result as [provided by initrams](https://github.com/omnect/meta-omnect?tab=readme-ov-file#factory-reset-result)
  - don't report `in_progress` anymore. return `Ok(None)` as successful result instead.
- report initial feature status all together instead of separate reports for each feature (improves efficiency and reduces test code)
- use retry policy in `web_service` in order to publish status messages to endpoints