### PR TITLE
chore: bump to rust edition 2024

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -21,16 +21,16 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa882656b67966045e4152c634051e70346939fced7117d5f0b52146a7c74c9"
+checksum = "44dfe5c9e0004c623edc65391dfd51daa201e7e30ebd9c9bedf873048ec32bc2"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
  "base64 0.22.1",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "brotli",
  "bytes",
  "bytestring",
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.5.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6398974fd4284f4768af07965701efbbb5fdc0616bff20cade1bb14b77675e24"
+checksum = "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.10.2"
+version = "4.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2e3b15b3dc6c6ed996e4032389e9849d4ab002b1e92fbfe85b5f307d1479b4d"
+checksum = "a597b77b5c6d6a1e1097fddde329a83665e25c5437c696a3a9a4aa514a614dea"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -313,81 +313,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-io"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
-dependencies = [
- "async-lock",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix 0.38.44",
- "slab",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-process"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
-dependencies = [
- "async-channel",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener",
- "futures-lite",
- "rustix 0.38.44",
- "tracing",
-]
-
-[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,30 +322,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "async-signal"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix 0.38.44",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -434,12 +335,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,7 +343,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 [[package]]
 name = "aziot-cert-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.0#b9fff6b2fdf9c1593a5a0b7e856a5f01c2c5ad5b"
+source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.5#1e38b9e5295cc09f0fd4c6b810632fd91e0340f5"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-key-common",
@@ -461,12 +356,12 @@ dependencies = [
 [[package]]
 name = "aziot-cert-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.0#b9fff6b2fdf9c1593a5a0b7e856a5f01c2c5ad5b"
+source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.5#1e38b9e5295cc09f0fd4c6b810632fd91e0340f5"
 
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.0#b9fff6b2fdf9c1593a5a0b7e856a5f01c2c5ad5b"
+source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.5#1e38b9e5295cc09f0fd4c6b810632fd91e0340f5"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -475,7 +370,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.0#b9fff6b2fdf9c1593a5a0b7e856a5f01c2c5ad5b"
+source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.5#1e38b9e5295cc09f0fd4c6b810632fd91e0340f5"
 dependencies = [
  "cert-renewal",
  "hex",
@@ -490,7 +385,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.0#b9fff6b2fdf9c1593a5a0b7e856a5f01c2c5ad5b"
+source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.5#1e38b9e5295cc09f0fd4c6b810632fd91e0340f5"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -504,7 +399,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.0#b9fff6b2fdf9c1593a5a0b7e856a5f01c2c5ad5b"
+source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.5#1e38b9e5295cc09f0fd4c6b810632fd91e0340f5"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -515,7 +410,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.0#b9fff6b2fdf9c1593a5a0b7e856a5f01c2c5ad5b"
+source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.5#1e38b9e5295cc09f0fd4c6b810632fd91e0340f5"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -528,7 +423,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.0#b9fff6b2fdf9c1593a5a0b7e856a5f01c2c5ad5b"
+source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.5#1e38b9e5295cc09f0fd4c6b810632fd91e0340f5"
 dependencies = [
  "aziot-identity-common",
  "cert-renewal",
@@ -543,7 +438,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.0#b9fff6b2fdf9c1593a5a0b7e856a5f01c2c5ad5b"
+source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.5#1e38b9e5295cc09f0fd4c6b810632fd91e0340f5"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -556,7 +451,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.0#b9fff6b2fdf9c1593a5a0b7e856a5f01c2c5ad5b"
+source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.5#1e38b9e5295cc09f0fd4c6b810632fd91e0340f5"
 dependencies = [
  "serde",
 ]
@@ -564,7 +459,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.0#b9fff6b2fdf9c1593a5a0b7e856a5f01c2c5ad5b"
+source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.5#1e38b9e5295cc09f0fd4c6b810632fd91e0340f5"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -574,7 +469,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.0#b9fff6b2fdf9c1593a5a0b7e856a5f01c2c5ad5b"
+source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.5#1e38b9e5295cc09f0fd4c6b810632fd91e0340f5"
 dependencies = [
  "http-common",
  "libc",
@@ -583,8 +478,8 @@ dependencies = [
 
 [[package]]
 name = "azure-iot-sdk"
-version = "0.14.0"
-source = "git+https://github.com/omnect/azure-iot-sdk.git?tag=0.14.0#37d1a0acfa234c71db887bb9193166afad6d466a"
+version = "0.14.1"
+source = "git+https://github.com/omnect/azure-iot-sdk.git?tag=0.14.1#e0a08e96e64121807908371a846edb7496c223e1"
 dependencies = [
  "anyhow",
  "azure-iot-sdk-sys",
@@ -598,8 +493,8 @@ dependencies = [
 
 [[package]]
 name = "azure-iot-sdk-sys"
-version = "0.6.2"
-source = "git+https://github.com/omnect/azure-iot-sdk-sys.git?tag=0.6.2#ca9d92d197b32e7597ea654f5542e696ec50499c"
+version = "0.6.3"
+source = "git+https://github.com/omnect/azure-iot-sdk-sys.git?tag=0.6.3#8d9be23763e935919fcc416e88c3c95e40dd3af5"
 dependencies = [
  "bindgen",
  "pkg-config",
@@ -644,7 +539,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -666,9 +561,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "block-buffer"
@@ -680,23 +575,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "blocking"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
-]
-
-[[package]]
 name = "brotli"
-version = "7.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+checksum = "9991eea70ea4f293524138648e41ee89b0b2b12ddef3b255effa43c8056e0e0d"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -705,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -736,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.21"
+version = "1.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
+checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
 dependencies = [
  "jobserver",
  "libc",
@@ -748,7 +630,7 @@ dependencies = [
 [[package]]
 name = "cert-renewal"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.0#b9fff6b2fdf9c1593a5a0b7e856a5f01c2c5ad5b"
+source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.5#1e38b9e5295cc09f0fd4c6b810632fd91e0340f5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1027,8 +909,8 @@ dependencies = [
 
 [[package]]
 name = "eis-utils"
-version = "0.3.3"
-source = "git+https://github.com/omnect/eis-utils.git?tag=0.3.3#bc4d78ddc33cb136aa242f25d09571e780825a94"
+version = "0.3.4"
+source = "git+https://github.com/omnect/eis-utils.git?tag=0.3.4#36fb179800b53cdc78a0b10ae726019ca78c64db"
 dependencies = [
  "aziot-cert-client-async",
  "aziot-cert-common",
@@ -1121,9 +1003,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -1375,9 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1459,12 +1341,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,7 +1405,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.0#b9fff6b2fdf9c1593a5a0b7e856a5f01c2c5ad5b"
+source = "git+https://github.com/Azure/iot-identity-service.git?tag=1.5.5#1e38b9e5295cc09f0fd4c6b810632fd91e0340f5"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -1717,21 +1593,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1741,30 +1618,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -1772,65 +1629,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1852,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1894,7 +1738,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "inotify-sys",
  "libc",
 ]
@@ -1947,7 +1791,7 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "libc",
 ]
 
@@ -2015,7 +1859,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "libc",
  "redox_syscall 0.5.12",
 ]
@@ -2037,21 +1881,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "local-channel"
@@ -2236,27 +2074,15 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.9.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
- "memoffset 0.9.1",
-]
-
-[[package]]
-name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -2275,7 +2101,7 @@ version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "filetime",
  "fsevent-sys",
  "inotify",
@@ -2410,7 +2236,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -2443,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-device-service"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "actix-server",
  "actix-web",
@@ -2509,7 +2335,7 @@ version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2630,35 +2456,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
-name = "polling"
-version = "3.7.4"
+name = "potential_utf"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
 dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix 0.38.44",
- "tracing",
- "windows-sys 0.59.0",
+ "zerovec",
 ]
 
 [[package]]
@@ -2801,7 +2610,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -2819,7 +2628,7 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -2965,27 +2774,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.9.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
+ "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
 
@@ -3055,7 +2851,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3356,9 +3152,9 @@ dependencies = [
 
 [[package]]
 name = "systemd-zbus"
-version = "5.2.0"
+version = "5.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa07c807e90d5c5c8bb1d1fbc7cb1b2f07364da19e42eee2109f72cddd89b62"
+checksum = "a767093bf0502888fc45f8e2cbc8b752afdb5d40d4ad483f560cf45289da7a08"
 dependencies = [
  "serde",
  "zbus",
@@ -3376,14 +3172,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -3466,9 +3262,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3701,12 +3497,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3714,9 +3504,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 
 [[package]]
 name = "vcpkg"
@@ -4160,9 +3950,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9fb597c990f03753e08d3c29efbfcf2019a003b4bf4ba19225c158e1549f0f3"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]
@@ -4173,20 +3963,14 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "x509-parser"
@@ -4207,9 +3991,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -4219,9 +4003,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4231,25 +4015,19 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.6.0"
+version = "5.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2522b82023923eecb0b366da727ec883ace092e7887b61d3da5139f26b44da58"
+checksum = "d3a7c7cee313d044fca3f48fa782cb750c79e4ca76ba7bc7718cd4024cdf6f68"
 dependencies = [
  "async-broadcast",
- "async-executor",
- "async-io",
- "async-lock",
- "async-process",
  "async-recursion",
- "async-task",
  "async-trait",
- "blocking",
  "enumflags2",
  "event-listener",
  "futures-core",
  "futures-lite",
  "hex",
- "nix 0.29.0",
+ "nix 0.30.1",
  "ordered-stream",
  "serde",
  "serde_repr",
@@ -4265,9 +4043,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.6.0"
+version = "5.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d2e12843c75108c00c618c2e8ef9675b50b6ec095b36dc965f2e5aed463c15"
+checksum = "a17e7e5eec1550f747e71a058df81a9a83813ba0f6a95f39c4e218bdc7ba366a"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4332,10 +4110,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4344,9 +4133,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4383,9 +4172,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.5.1"
+version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "557e89d54880377a507c94cd5452f20e35d14325faf9d2958ebeadce0966c1b2"
+checksum = "9d30786f75e393ee63a21de4f9074d4c038d52c5b1bb4471f955db249f9dffb1"
 dependencies = [
  "endi",
  "enumflags2",
@@ -4397,9 +4186,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.5.1"
+version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757779842a0d242061d24c28be589ce392e45350dfb9186dfd7a042a2e19870c"
+checksum = "75fda702cd42d735ccd48117b1630432219c0e9616bf6cb0f8350844ee4d9580"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,19 +2,19 @@
 authors = ["omnect@conplement.de"]
 build = "src/build.rs"
 description = "This service allows remote features like: user fw update consent, factory reset, network adapter status and reboot."
-edition = "2021"
+edition = "2024"
 homepage = "www.omnect.io"
 license = "MIT OR Apache-2.0"
 name = "omnect-device-service"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-device-service.git"
-version = "0.41.0"
+version = "0.41.1"
 
 [dependencies]
-actix-server = { version = "2.3", default-features = false }
-actix-web = { version = "4.9", default-features = false }
+actix-server = { version = "2.6", default-features = false }
+actix-web = { version = "4.11", default-features = false }
 anyhow = { version = "1.0", default-features = false }
-azure-iot-sdk = { git = "https://github.com/omnect/azure-iot-sdk.git", tag = "0.14.0", default-features = false, features = [
+azure-iot-sdk = { git = "https://github.com/omnect/azure-iot-sdk.git", tag = "0.14.1", default-features = false, features = [
   "module_client",
 ] }
 base64 = { version = "0.22", default-features = false }
@@ -25,7 +25,7 @@ freedesktop_entry_parser = { version = "1.3", default-features = false }
 futures = { version = "0.3", default-features = false }
 futures-util = { version = "0.3", default-features = false }
 glob = { version = "0.3", default-features = false }
-lazy_static = { version = "1.4", default-features = false }
+lazy_static = { version = "1.5", default-features = false }
 log = { version = "0.4", default-features = false }
 log-panics = { version = "2", default-features = false }
 modemmanager = { git = "https://github.com/omnect/modemmanager.git", tag = "0.3.4", default-features = false, optional = true }
@@ -42,7 +42,7 @@ sd-notify = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
 serde_repr = { version = "0.1", default-features = false }
-serde_with = { version = "3.8", default-features = false, features = [
+serde_with = { version = "3.12", default-features = false, features = [
   "std",
   "macros",
 ] }
@@ -57,7 +57,7 @@ sysinfo = { version = "0.35", default-features = false, features = [
   "disk",
   "system",
 ] }
-systemd-zbus = { version = "5.1", default-features = false }
+systemd-zbus = { version = "5.3", default-features = false }
 tar = { version = "0.4", default-features = false }
 time = { version = "0.3", default-features = false, features = ["formatting"] }
 tokio = { version = "1", default-features = false }
@@ -65,9 +65,9 @@ tokio-stream = { version = "0.1", default-features = false, features = [
   "time",
 ] }
 toml = { version = "0.8", default-features = false, features = ["parse"] }
-uuid = { version = "1.4", default-features = false }
+uuid = { version = "1.17", default-features = false }
 x509-parser = { version = "0.17", default-features = false }
-zbus = { version = "5.3", default-features = false, features = ["tokio"] }
+zbus = { version = "5.7", default-features = false, features = ["tokio"] }
 
 [dev-dependencies]
 actix-web = "4"
@@ -78,7 +78,7 @@ mockall = "0.13"
 rand = "0.9"
 regex = "1"
 omnect-device-service = { path = ".", features = ["mock"] }
-tempfile = "3.14"
+tempfile = "3.20"
 
 [features]
 default = []

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.83.0"
+channel = "1.87.0"

--- a/src/common.rs
+++ b/src/common.rs
@@ -117,3 +117,20 @@ where
 {
     path.as_ref().to_string_lossy().ends_with(end)
 }
+
+#[cfg(test)]
+pub fn set_env_var<K, V>(key: K, value: V)
+where
+    K: AsRef<std::ffi::OsStr>,
+    V: AsRef<std::ffi::OsStr>,
+{
+    unsafe { std::env::set_var(key, value) };
+}
+
+#[cfg(test)]
+pub fn remove_env_var<K>(key: K)
+where
+    K: AsRef<std::ffi::OsStr>,
+{
+    unsafe { std::env::remove_var(key) };
+}

--- a/src/reboot_reason.rs
+++ b/src/reboot_reason.rs
@@ -110,7 +110,7 @@ mod tests {
 
     #[test]
     fn current_reboot_reason_ok() {
-        std::env::set_var("REBOOT_REASON_DIR_PATH", "testfiles/positive/reboot_reason");
+        crate::common::set_env_var("REBOOT_REASON_DIR_PATH", "testfiles/positive/reboot_reason");
         assert_eq!(
             current_reboot_reason(),
             Some(json!( {

--- a/src/systemd/networkd.rs
+++ b/src/systemd/networkd.rs
@@ -152,12 +152,12 @@ mod tests {
 
     #[test]
     fn networkd_wait_online_timeout_invalid_input() {
-        std::env::set_var("WAIT_ONLINE_SERVICE_FILE_PATH", "");
+        crate::common::set_env_var("WAIT_ONLINE_SERVICE_FILE_PATH", "");
         assert!(networkd_wait_online_timeout()
             .unwrap_err()
             .to_string()
             .starts_with("service file missing"));
-        std::env::set_var(
+        crate::common::set_env_var(
             "WAIT_ONLINE_SERVICE_FILE_PATH",
             "testfiles/negative/systemd-networkd-wait-online-no-execstart.service",
         );
@@ -165,7 +165,7 @@ mod tests {
             .unwrap_err()
             .to_string()
             .starts_with("ExecStart entry missing"));
-        std::env::set_var(
+        crate::common::set_env_var(
             "WAIT_ONLINE_SERVICE_FILE_PATH",
             "testfiles/negative/systemd-networkd-wait-online-invalid-timeout.service",
         );
@@ -173,7 +173,7 @@ mod tests {
             .unwrap_err()
             .to_string()
             .starts_with("unexpected timeout config in ExecStart"));
-        std::env::set_var(
+        crate::common::set_env_var(
             "WAIT_ONLINE_SERVICE_FILE_PATH",
             "testfiles/negative/systemd-networkd-wait-online-no-envfile.service",
         );
@@ -181,7 +181,7 @@ mod tests {
             .unwrap_err()
             .to_string()
             .starts_with("EnvironmentFile entry missing"));
-        std::env::set_var(
+        crate::common::set_env_var(
             "WAIT_ONLINE_SERVICE_FILE_PATH",
             "testfiles/negative/systemd-networkd-wait-online-invalid-envfile.service",
         );
@@ -190,11 +190,11 @@ mod tests {
             .to_string()
             .starts_with("unexpected path in EnvironmentFile"));
 
-        std::env::set_var(
+        crate::common::set_env_var(
             "WAIT_ONLINE_SERVICE_FILE_PATH",
             "testfiles/negative/systemd-networkd-wait-online-invalid-default-timeout.service",
         );
-        std::env::set_var(
+        crate::common::set_env_var(
             "ENV_FILE_PATH",
             "testfiles/negative/systemd-networkd-wait-online-invalid-timeout.env",
         );
@@ -203,27 +203,27 @@ mod tests {
             .to_string()
             .starts_with("cannot parse OMNECT_WAIT_ONLINE_TIMEOUT_IN_SECS"));
 
-        std::env::remove_var("WAIT_ONLINE_SERVICE_FILE_PATH");
-        std::env::remove_var("ENV_FILE_PATH");
+        crate::common::remove_env_var("WAIT_ONLINE_SERVICE_FILE_PATH");
+        crate::common::remove_env_var("ENV_FILE_PATH");
     }
 
     #[test]
     fn networkd_wait_online_timeout_ok() {
         let _ = fs::remove_file("/tmp/systemd-networkd-wait-online1.env");
-        std::env::set_var(
+        crate::common::set_env_var(
             "WAIT_ONLINE_SERVICE_FILE_PATH",
             "testfiles/positive/systemd-networkd-wait-online-no-envfile.service",
         );
-        std::env::set_var("ENV_FILE_PATH", "/tmp/systemd-networkd-wait-online1.env");
+        crate::common::set_env_var("ENV_FILE_PATH", "/tmp/systemd-networkd-wait-online1.env");
         assert_eq!(
             networkd_wait_online_timeout().unwrap(),
             Some(Duration::from_secs(300))
         );
-        std::env::set_var(
+        crate::common::set_env_var(
             "WAIT_ONLINE_SERVICE_FILE_PATH",
             "testfiles/positive/systemd-networkd-wait-online-env1.service",
         );
-        std::env::set_var(
+        crate::common::set_env_var(
             "ENV_FILE_PATH",
             "testfiles/positive/systemd-networkd-wait-online1.env",
         );
@@ -231,20 +231,20 @@ mod tests {
             networkd_wait_online_timeout().unwrap(),
             Some(Duration::from_secs(1))
         );
-        std::env::set_var(
+        crate::common::set_env_var(
             "WAIT_ONLINE_SERVICE_FILE_PATH",
             "testfiles/positive/systemd-networkd-wait-online-env2.service",
         );
-        std::env::set_var(
+        crate::common::set_env_var(
             "ENV_FILE_PATH",
             "testfiles/positive/systemd-networkd-wait-online2.env",
         );
         assert_eq!(networkd_wait_online_timeout().unwrap(), None);
-        std::env::set_var(
+        crate::common::set_env_var(
             "WAIT_ONLINE_SERVICE_FILE_PATH",
             "testfiles/positive/systemd-networkd-wait-online-env3.service",
         );
-        std::env::set_var(
+        crate::common::set_env_var(
             "ENV_FILE_PATH",
             "testfiles/positive/systemd-networkd-wait-online3.env",
         );
@@ -253,18 +253,18 @@ mod tests {
             Some(Duration::from_secs(300))
         );
 
-        std::env::remove_var("WAIT_ONLINE_SERVICE_FILE_PATH");
-        std::env::remove_var("ENV_FILE_PATH");
+        crate::common::remove_env_var("WAIT_ONLINE_SERVICE_FILE_PATH");
+        crate::common::remove_env_var("ENV_FILE_PATH");
     }
 
     #[test]
     fn set_networkd_wait_online_timeout_ok() {
         let _ = fs::remove_file("/tmp/systemd-networkd-wait-online1.env");
-        std::env::set_var(
+        crate::common::set_env_var(
             "WAIT_ONLINE_SERVICE_FILE_PATH",
             "testfiles/positive/systemd-networkd-wait-online-no-envfile.service",
         );
-        std::env::set_var("ENV_FILE_PATH", "/tmp/systemd-networkd-wait-online1.env");
+        crate::common::set_env_var("ENV_FILE_PATH", "/tmp/systemd-networkd-wait-online1.env");
         assert!(set_networkd_wait_online_timeout(Some(Duration::from_secs(100))).is_ok());
         assert_eq!(
             fs::read_to_string("/tmp/systemd-networkd-wait-online1.env").unwrap(),
@@ -283,7 +283,7 @@ mod tests {
             "env=1\nOMNECT_WAIT_ONLINE_TIMEOUT_IN_SECS=\"0\""
         );
 
-        std::env::remove_var("WAIT_ONLINE_SERVICE_FILE_PATH");
-        std::env::remove_var("ENV_FILE_PATH");
+        crate::common::remove_env_var("WAIT_ONLINE_SERVICE_FILE_PATH");
+        crate::common::remove_env_var("ENV_FILE_PATH");
     }
 }

--- a/src/twin/consent.rs
+++ b/src/twin/consent.rs
@@ -262,7 +262,7 @@ mod tests {
 
         let tmp_dir = tempfile::tempdir().unwrap();
         let consent_conf_file = tmp_dir.path().join("consent_conf.json");
-        std::env::set_var("CONSENT_DIR_PATH", tmp_dir.path());
+        crate::common::set_env_var("CONSENT_DIR_PATH", tmp_dir.path());
 
         std::fs::copy("testfiles/negative/consent_conf.json", &consent_conf_file).unwrap();
 
@@ -357,7 +357,7 @@ mod tests {
             .any(|e| e.to_string().starts_with("failed to open for write: ")));
 
         let tmp_dir = tempfile::tempdir().unwrap();
-        std::env::set_var("CONSENT_DIR_PATH", tmp_dir.path());
+        crate::common::set_env_var("CONSENT_DIR_PATH", tmp_dir.path());
         let foo_dir = tmp_dir.path().join("foo");
         std::fs::create_dir(foo_dir.clone()).unwrap();
         std::fs::copy(

--- a/src/twin/factory_reset.rs
+++ b/src/twin/factory_reset.rs
@@ -230,12 +230,12 @@ mod tests {
         .unwrap();
         std::fs::create_dir_all(custom_dir_path.clone()).unwrap();
 
-        std::env::set_var(
+        crate::common::set_env_var(
             "FACTORY_RESET_STATUS_FILE_PATH",
             "testfiles/positive/factory-reset-status_succeeded",
         );
-        std::env::set_var("FACTORY_RESET_CONFIG_FILE_PATH", config_file_path.clone());
-        std::env::set_var("FACTORY_RESET_CUSTOM_CONFIG_DIR_PATH", custom_dir_path);
+        crate::common::set_env_var("FACTORY_RESET_CONFIG_FILE_PATH", config_file_path.clone());
+        crate::common::set_env_var("FACTORY_RESET_CUSTOM_CONFIG_DIR_PATH", custom_dir_path);
 
         let mut factory_reset = FactoryReset::new().unwrap();
 
@@ -289,7 +289,7 @@ mod tests {
 
     #[test]
     fn factory_reset_keys_test() {
-        std::env::set_var(
+        crate::common::set_env_var(
             "FACTORY_RESET_CONFIG_FILE_PATH",
             "testfiles/positive/factory-rest.json",
         );
@@ -300,7 +300,7 @@ mod tests {
 
         let tmp_dir = tempfile::tempdir().unwrap();
         let file_path = tmp_dir.path().join("factory-reset.json");
-        std::env::set_var("FACTORY_RESET_CONFIG_FILE_PATH", file_path.clone());
+        crate::common::set_env_var("FACTORY_RESET_CONFIG_FILE_PATH", file_path.clone());
 
         std::fs::copy(
             "testfiles/positive/factory-reset.json",
@@ -315,20 +315,20 @@ mod tests {
 
         let custom_dir_path = tmp_dir.path().join("factory-reset.d");
         std::fs::create_dir(custom_dir_path.clone()).unwrap();
-        std::env::set_var("FACTORY_RESET_CUSTOM_CONFIG_DIR_PATH", custom_dir_path);
+        crate::common::set_env_var("FACTORY_RESET_CUSTOM_CONFIG_DIR_PATH", custom_dir_path);
 
         FactoryReset::factory_reset_keys().unwrap();
     }
 
     #[test]
     fn factory_reset_status_test() {
-        std::env::set_var("FACTORY_RESET_STATUS_FILE_PATH", "");
+        crate::common::set_env_var("FACTORY_RESET_STATUS_FILE_PATH", "");
         assert!(FactoryReset::factory_reset_result()
             .unwrap_err()
             .to_string()
             .starts_with("failed to open for read"));
 
-        std::env::set_var(
+        crate::common::set_env_var(
             "FACTORY_RESET_STATUS_FILE_PATH",
             "testfiles/negative/factory-reset-status_unexpected_factory_reset_format",
         );
@@ -337,7 +337,7 @@ mod tests {
             .to_string()
             .starts_with("failed to parse factory reset result from initramfs"));
 
-        std::env::set_var(
+        crate::common::set_env_var(
             "FACTORY_RESET_STATUS_FILE_PATH",
             "testfiles/positive/factory-reset-status_succeeded",
         );
@@ -351,7 +351,7 @@ mod tests {
             }
         );
 
-        std::env::set_var(
+        crate::common::set_env_var(
             "FACTORY_RESET_STATUS_FILE_PATH",
             "testfiles/positive/factory-reset-status_normal_boot",
         );

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -473,9 +473,9 @@ mod tests {
         std::fs::copy("testfiles/positive/du-config.json", &du_config_file).unwrap();
         std::fs::copy("testfiles/positive/sw-versions", &sw_versions_file).unwrap();
         std::fs::create_dir_all(&update_folder).unwrap();
-        std::env::set_var("UPDATE_FOLDER_PATH", update_folder);
-        std::env::set_var("DEVICE_UPDATE_PATH", du_config_file);
-        std::env::set_var("SW_VERSIONS_PATH", sw_versions_file);
+        crate::common::set_env_var("UPDATE_FOLDER_PATH", update_folder);
+        crate::common::set_env_var("DEVICE_UPDATE_PATH", du_config_file);
+        crate::common::set_env_var("SW_VERSIONS_PATH", sw_versions_file);
         let (tx_validated, mut _rx_validated) = tokio::sync::oneshot::channel();
         let update_validation = UpdateValidation::new(tx_validated).await.unwrap();
 
@@ -498,9 +498,9 @@ mod tests {
         let sw_versions_file = tmp_dir.path().join("sw-versions");
         std::fs::copy("testfiles/positive/du-config.json", &du_config_file).unwrap();
         std::fs::create_dir_all(&update_folder).unwrap();
-        std::env::set_var("UPDATE_FOLDER_PATH", update_folder);
-        std::env::set_var("DEVICE_UPDATE_PATH", du_config_file);
-        std::env::set_var("SW_VERSIONS_PATH", &sw_versions_file);
+        crate::common::set_env_var("UPDATE_FOLDER_PATH", update_folder);
+        crate::common::set_env_var("DEVICE_UPDATE_PATH", du_config_file);
+        crate::common::set_env_var("SW_VERSIONS_PATH", &sw_versions_file);
         let (tx_validated, mut _rx_validated) = tokio::sync::oneshot::channel();
         let update_validation = UpdateValidation::new(tx_validated).await.unwrap();
 
@@ -544,9 +544,9 @@ mod tests {
         let sw_versions_file = tmp_dir.path().join("sw-versions");
         std::fs::copy("testfiles/positive/sw-versions", &sw_versions_file).unwrap();
         std::fs::create_dir_all(&update_folder).unwrap();
-        std::env::set_var("UPDATE_FOLDER_PATH", update_folder);
-        std::env::set_var("DEVICE_UPDATE_PATH", &du_config_file);
-        std::env::set_var("SW_VERSIONS_PATH", sw_versions_file);
+        crate::common::set_env_var("UPDATE_FOLDER_PATH", update_folder);
+        crate::common::set_env_var("DEVICE_UPDATE_PATH", &du_config_file);
+        crate::common::set_env_var("SW_VERSIONS_PATH", sw_versions_file);
         let (tx_validated, mut _rx_validated) = tokio::sync::oneshot::channel();
         let update_validation = UpdateValidation::new(tx_validated).await.unwrap();
 

--- a/src/twin/firmware_update/os_version.rs
+++ b/src/twin/firmware_update/os_version.rs
@@ -122,7 +122,7 @@ mod tests {
         assert!(OmnectOsVersion::from_string("123.123.123.123.123").is_err());
         assert!(OmnectOsVersion::from_string("asdf.123.123.123").is_err());
 
-        std::env::set_var("SW_VERSIONS_PATH", "testfiles/positive/sw-versions");
+        crate::common::set_env_var("SW_VERSIONS_PATH", "testfiles/positive/sw-versions");
 
         assert!(
             OmnectOsVersion::from_sw_versions_file().unwrap()

--- a/src/twin/mod_test.rs
+++ b/src/twin/mod_test.rs
@@ -172,45 +172,47 @@ pub mod mod_test {
             test_env.mkdir("empty-dir");
 
             // set env vars
-            env::set_var("SSH_TUNNEL_DIR_PATH", test_env.dirpath().as_str());
-            env::set_var("OS_RELEASE_DIR_PATH", test_env.dirpath().as_str());
-            env::set_var("CONSENT_DIR_PATH", test_env.dirpath().as_str());
-            env::set_var("WPA_SUPPLICANT_DIR_PATH", test_env.dirpath().as_str());
-            env::set_var(
+            crate::common::set_env_var("SSH_TUNNEL_DIR_PATH", test_env.dirpath().as_str());
+            crate::common::set_env_var("OS_RELEASE_DIR_PATH", test_env.dirpath().as_str());
+            crate::common::set_env_var("CONSENT_DIR_PATH", test_env.dirpath().as_str());
+            crate::common::set_env_var("WPA_SUPPLICANT_DIR_PATH", test_env.dirpath().as_str());
+            crate::common::set_env_var(
                 "WAIT_ONLINE_SERVICE_FILE_PATH",
                 format!(
                     "{}/systemd-networkd-wait-online.service",
                     test_env.dirpath()
                 ),
             );
-            env::set_var(
+            crate::common::set_env_var(
                 "FACTORY_RESET_CONFIG_FILE_PATH",
                 format!("{}/factory-reset.json", test_env.dirpath()),
             );
-            env::set_var(
+            crate::common::set_env_var(
                 "FACTORY_RESET_STATUS_FILE_PATH",
                 format!("{}/factory-reset-status_succeeded", test_env.dirpath()),
             );
-            env::set_var(
+            crate::common::set_env_var(
                 "FACTORY_RESET_CUSTOM_CONFIG_DIR_PATH",
                 format!("{}/empty-dir", test_env.dirpath()),
             );
-            env::set_var("CONNECTION_STRING", "my-constr");
-            env::set_var(
+            crate::common::set_env_var("CONNECTION_STRING", "my-constr");
+            crate::common::set_env_var(
                 "IDENTITY_CONFIG_FILE_PATH",
                 format!("{}/config.toml.est", test_env.dirpath()),
             );
-            env::set_var(
+            crate::common::set_env_var(
                 "EST_CERT_FILE_PATH",
                 format!("{}/deviceid1-bd732105ef89cf8edd2606a5309c8a26b7b5599a4e124a0fe6199b6b2f60e655.cer", test_env.dirpath()),
             );
-            env::set_var(
+            crate::common::set_env_var(
                 "DEVICE_CERT_FILE",
                 format!("{}/ssh_root_ca.pub", test_env.dirpath()),
             );
-            std::env::set_var("REBOOT_REASON_DIR_PATH", "testfiles/positive/reboot_reason");
+            crate::common::set_env_var("REBOOT_REASON_DIR_PATH", "testfiles/positive/reboot_reason");
 
-            env_vars.iter().for_each(|env| env::set_var(env.0, env.1));
+            env_vars
+                .iter()
+                .for_each(|env| crate::common::set_env_var(env.0, env.1));
 
             // create iothub client mock
             let ctx = MockMyIotHub::builder_context();
@@ -272,17 +274,19 @@ pub mod mod_test {
             }
 
             // cleanup env vars
-            env::remove_var("SSH_TUNNEL_DIR_PATH");
-            env::remove_var("OS_RELEASE_DIR_PATH");
-            env::remove_var("CONSENT_DIR_PATH");
-            env::remove_var("WPA_SUPPLICANT_DIR_PATH");
-            env::remove_var("WAIT_ONLINE_SERVICE_FILE_PATH");
-            env::remove_var("FACTORY_RESET_CONFIG_FILE_PATH");
-            env::remove_var("FACTORY_RESET_STATUS_FILE_PATH");
-            env::remove_var("FACTORY_RESET_CUSTOM_CONFIG_DIR_PATH");
-            env::remove_var("IDENTITY_CONFIG_FILE_PATH");
-            env::remove_var("EST_CERT_FILE_PATH");
-            env_vars.iter().for_each(|e| env::remove_var(e.0));
+            crate::common::remove_env_var("SSH_TUNNEL_DIR_PATH");
+            crate::common::remove_env_var("OS_RELEASE_DIR_PATH");
+            crate::common::remove_env_var("CONSENT_DIR_PATH");
+            crate::common::remove_env_var("WPA_SUPPLICANT_DIR_PATH");
+            crate::common::remove_env_var("WAIT_ONLINE_SERVICE_FILE_PATH");
+            crate::common::remove_env_var("FACTORY_RESET_CONFIG_FILE_PATH");
+            crate::common::remove_env_var("FACTORY_RESET_STATUS_FILE_PATH");
+            crate::common::remove_env_var("FACTORY_RESET_CUSTOM_CONFIG_DIR_PATH");
+            crate::common::remove_env_var("IDENTITY_CONFIG_FILE_PATH");
+            crate::common::remove_env_var("EST_CERT_FILE_PATH");
+            env_vars
+                .iter()
+                .for_each(|e| crate::common::remove_env_var(e.0));
         }
     }
 

--- a/src/twin/provisioning_config.rs
+++ b/src/twin/provisioning_config.rs
@@ -267,17 +267,17 @@ mod tests {
 
     #[test]
     fn provisioning_config_test() {
-        env::set_var("IDENTITY_CONFIG_FILE_PATH", "");
+        crate::common::set_env_var("IDENTITY_CONFIG_FILE_PATH", "");
         assert!(ProvisioningConfig::new()
             .unwrap_err()
             .to_string()
             .starts_with("provisioning_config: cannot read"));
 
-        env::set_var(
+        crate::common::set_env_var(
             "IDENTITY_CONFIG_FILE_PATH",
             "testfiles/positive/config.toml.est",
         );
-        env::set_var("EST_CERT_FILE_PATH", "testfiles/positive/deviceid1-*.cer");
+        crate::common::set_env_var("EST_CERT_FILE_PATH", "testfiles/positive/deviceid1-*.cer");
         assert_eq!(
             serde_json::to_value(ProvisioningConfig::new().unwrap()).unwrap(),
             json!({
@@ -291,7 +291,7 @@ mod tests {
             })
         );
 
-        env::set_var(
+        crate::common::set_env_var(
             "IDENTITY_CONFIG_FILE_PATH",
             "testfiles/positive/config.toml.tpm",
         );
@@ -306,12 +306,12 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn provisioning_refresh_test() {
-        env::set_var(
+        crate::common::set_env_var(
             "IDENTITY_CONFIG_FILE_PATH",
             "testfiles/positive/config.toml.est",
         );
 
-        env::set_var("EST_CERT_FILE_PATH", "testfiles/positive/deviceid1-*.cer");
+        crate::common::set_env_var("EST_CERT_FILE_PATH", "testfiles/positive/deviceid1-*.cer");
 
         let mut config = ProvisioningConfig::new().unwrap();
 
@@ -332,7 +332,7 @@ mod tests {
             panic!("no X509 found");
         };
 
-        env::set_var("EST_CERT_FILE_PATH", "testfiles/positive/deviceid2-*.cer");
+        crate::common::set_env_var("EST_CERT_FILE_PATH", "testfiles/positive/deviceid2-*.cer");
 
         config
             .command(&Command::Interval(IntervalCommand {

--- a/src/twin/ssh_tunnel.rs
+++ b/src/twin/ssh_tunnel.rs
@@ -696,7 +696,7 @@ mod tests {
         };
         let tmp_dir = tempfile::tempdir().unwrap();
         let tmp_file = tmp_dir.path().join("some-ca-file");
-        env::set_var("DEVICE_CERT_FILE", &tmp_file);
+        crate::common::set_env_var("DEVICE_CERT_FILE", &tmp_file);
 
         let _response = ssh_tunnel.report().await.unwrap();
 
@@ -724,7 +724,7 @@ mod tests {
             ssh_tunnel_semaphore: Arc::new(Semaphore::new(MAX_ACTIVE_TUNNELS)),
         };
         let tmp_file = tempfile::NamedTempFile::new().unwrap();
-        env::set_var("DEVICE_CERT_FILE", &tmp_file.path());
+        crate::common::set_env_var("DEVICE_CERT_FILE", &tmp_file.path());
 
         std::fs::write(&tmp_file, format!("{CERTIFICATE_DATA}\n")).unwrap();
 
@@ -754,7 +754,7 @@ mod tests {
             ssh_tunnel_semaphore: Arc::new(Semaphore::new(MAX_ACTIVE_TUNNELS)),
         };
         let tmp_file = tempfile::NamedTempFile::new().unwrap();
-        env::set_var("DEVICE_CERT_FILE", &tmp_file.path());
+        crate::common::set_env_var("DEVICE_CERT_FILE", &tmp_file.path());
 
         let _response = ssh_tunnel
             .command(&FeatureCommand::DesiredUpdateDeviceSshCa(
@@ -791,7 +791,7 @@ mod tests {
             ssh_tunnel_semaphore: Arc::new(Semaphore::new(MAX_ACTIVE_TUNNELS)),
         };
         let tmp_dir = tempfile::tempdir().unwrap();
-        env::set_var("SSH_TUNNEL_DIR_PATH", tmp_dir.path());
+        crate::common::set_env_var("SSH_TUNNEL_DIR_PATH", tmp_dir.path());
 
         // test creation of pub key
         let tunnel_id = "b054a76d-520c-40a9-b401-0f6bfb7cee9b".to_string();
@@ -847,7 +847,7 @@ mod tests {
         let tmp_dir = tempfile::tempdir().unwrap();
         let cert_path = tmp_dir.path().join("cert.pub");
         std::fs::copy("testfiles/positive/cert.pub", cert_path.clone()).unwrap();
-        env::set_var("SSH_TUNNEL_DIR_PATH", tmp_dir.path());
+        crate::common::set_env_var("SSH_TUNNEL_DIR_PATH", tmp_dir.path());
 
         // test successful
         ssh_tunnel


### PR DESCRIPTION
All `set_env` and `remove_env` calls are unsafe since edition 2024. Thus moved calls to separate functions in order to have only two locations where `unsafe` is used. We use these functions currently only in test code.