### PR TITLE
fix(reboot-reason): log update validation failure only for erroneous termination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,7 +2429,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-device-service"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "actix-server",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-device-service"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-device-service.git"
-version = "0.40.0"
+version = "0.40.1"
 
 [dependencies]
 actix-server = { version = "2.3", default-features = false }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,13 @@ async fn main() {
 
     info!("application shutdown");
 
-    // ensure that we terminate here right now
-    process::exit(0)
+    // FIXME:
+    //   under some circumstances the app can hang at termination what can be
+    //   worked aroung by explicitly issuing exit here.
+    //   to ease further examination of that problem allow setting an
+    //   environment variable to skip the workaround.
+    if let Err(dont_explicitly_exit) = env::var("DONT_EXPLICITLY_EXIT_ON_TERMINATION") {
+        // ensure that we terminate here right now
+        process::exit(0);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,10 +51,10 @@ async fn main() {
 
     // FIXME:
     //   under some circumstances the app can hang at termination what can be
-    //   worked aroung by explicitly issuing exit here.
+    //   worked around by explicitly issuing exit here.
     //   to ease further examination of that problem allow setting an
     //   environment variable to skip the workaround.
-    if let Err(dont_explicitly_exit) = env::var("DONT_EXPLICITLY_EXIT_ON_TERMINATION") {
+    if let Err(_) = env::var("DONT_EXPLICITLY_EXIT_ON_TERMINATION") {
         // ensure that we terminate here right now
         process::exit(0);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,5 +47,6 @@ async fn main() {
         process::exit(1);
     }
 
-    info!("application shutdown")
+    info!("application shutdown");
+    process::exit(0)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,5 +48,7 @@ async fn main() {
     }
 
     info!("application shutdown");
+
+    // ensure that we terminate here right now
     process::exit(0)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ pub mod web_service;
 
 use env_logger::{Builder, Env, Target};
 use log::{error, info};
-use std::{io::Write, process};
+use std::{env, io::Write, process};
 use twin::Twin;
 
 #[tokio::main]

--- a/src/twin/firmware_update/update_validation.rs
+++ b/src/twin/firmware_update/update_validation.rs
@@ -138,6 +138,7 @@ impl UpdateValidation {
                     }
                     _ => info!("reboot timer canceled."),
                 }
+                error!("update validation timed out: after match!");
             }));
         }
         new_self.tx_validated = Some(tx_validated);

--- a/src/twin/firmware_update/update_validation.rs
+++ b/src/twin/firmware_update/update_validation.rs
@@ -138,7 +138,7 @@ impl UpdateValidation {
                     }
                     _ => info!("reboot timer canceled."),
                 }
-                error!("update validation timed out: after match!");
+                debug!("update validation timed out: after match!");
             }));
         }
         new_self.tx_validated = Some(tx_validated);

--- a/src/twin/mod.rs
+++ b/src/twin/mod.rs
@@ -313,6 +313,7 @@ impl Twin {
         if let Some(ws) = &self.web_service {
             ws.shutdown().await;
         }
+        info!("twin shutdown complete");
     }
 
     async fn reset_client_with_delay(&mut self, timeout: Option<time::Duration>) {

--- a/src/web_service.rs
+++ b/src/web_service.rs
@@ -170,6 +170,7 @@ impl WebService {
         debug!("WebService shutdown");
 
         self.srv_handle.stop(false).await;
+
         debug!("WebService shutdown complete");
     }
 

--- a/src/web_service.rs
+++ b/src/web_service.rs
@@ -170,6 +170,7 @@ impl WebService {
         debug!("WebService shutdown");
 
         self.srv_handle.stop(false).await;
+        debug!("WebService shutdown complete");
     }
 
     async fn register_publish_endpoint(

--- a/systemd/omnect-device-service.exec_stop_post.sh
+++ b/systemd/omnect-device-service.exec_stop_post.sh
@@ -9,9 +9,15 @@ echo SERVICE_RESULT=${SERVICE_RESULT}, EXIT_CODE=${EXIT_CODE}, EXIT_STATUS=${EXI
 
 function reboot() {
   echo "reboot triggered by ${script}: ${1}"
-  /usr/sbin/omnect_reboot_reason.sh log swupdate-validation-failed "${1}"
+  [ "${log_reboot_reason}" ] && \
+      /usr/sbin/omnect_reboot_reason.sh log swupdate-validation-failed "${1}"
   dbus-send --system --print-reply --dest=org.freedesktop.login1 /org/freedesktop/login1 "org.freedesktop.login1.Manager.Reboot" boolean:true
 }
+
+# reboot reason loggin shall only happen if omnect-device-service exited with
+# en error
+log_reboot_reason=
+[ "${EXIT_STATUS}" = 0 ] || log_reboot_reason=1
 
 # for now we ignore SERVICE_RESULT and EXIT_STATUS. however it does potentially
 # make sense to reboot on certain combinations even if restart_count < max_restart_count


### PR DESCRIPTION
NOTE: this change also contains a FIXME in omnect-device-service's main function which addresses that an explicit exit call at the end should actually not be required.
To help further investigating on that issue an environment variable named DONT_EXPLICITLY_EXIT_ON_TERMINATION can be set to skip the exit call.