### PR TITLE
refactor: replace timeout by deadline in systemd and update validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -618,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.24"
+version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "jobserver",
  "libc",
@@ -1495,7 +1495,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "openssl-sys",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "tokio",
  "tokio-openssl",
  "tower-layer",
@@ -1549,17 +1549,21 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1771,6 +1775,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf0c5a3f977f1cebd92cf05ebb14e1c941c642fb57c9a7d4302455b33ba326f"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -1845,12 +1859,12 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -1910,9 +1924,9 @@ checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1980,14 +1994,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2269,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-device-service"
-version = "0.41.4"
+version = "0.41.5"
 dependencies = [
  "actix-server",
  "actix-web",
@@ -2291,7 +2305,6 @@ dependencies = [
  "log-panics",
  "mockall",
  "modemmanager",
- "nix 0.30.1",
  "notify",
  "notify-debouncer-full",
  "omnect-device-service",
@@ -2331,9 +2344,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl"
-version = "0.10.72"
+version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
@@ -2363,9 +2376,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.108"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -2402,12 +2415,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.10",
+ "parking_lot_core 0.9.11",
 ]
 
 [[package]]
@@ -2426,9 +2439,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2513,9 +2526,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -2668,14 +2681,13 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "a2f8e5513d63f2e5b386eb5106dc67eaf3f84e95258e210489136b8b92ad6119"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
- "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -2690,7 +2702,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2698,12 +2710,12 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows-registry",
 ]
 
 [[package]]
@@ -2786,25 +2798,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
+name = "rustls-pki-types"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
- "rustls-pki-types",
+ "zeroize",
 ]
 
 [[package]]
-name = "rustls-pki-types"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
-
-[[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -3020,9 +3026,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -3066,9 +3072,9 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -3138,9 +3144,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.35.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b897c8ea620e181c7955369a31be5f48d9a9121cb59fd33ecef9ff2a34323422"
+checksum = "79251336d17c72d9762b8b54be4befe38d2db56fbbc0241396d70f173c39d47a"
 dependencies = [
  "libc",
  "memchr",
@@ -3272,15 +3278,15 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -3390,6 +3396,24 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -3705,25 +3729,26 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
  "windows-result",
- "windows-strings 0.4.0",
+ "windows-strings",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core",
  "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3765,39 +3790,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
-dependencies = [
- "windows-result",
- "windows-strings 0.3.1",
- "windows-targets 0.53.0",
-]
-
-[[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]
@@ -3850,6 +3855,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -4108,6 +4122,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-device-service"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-device-service.git"
-version = "0.41.4"
+version = "0.41.5"
 
 [dependencies]
 actix-server = { version = "2.6", default-features = false }
@@ -29,7 +29,6 @@ lazy_static = { version = "1.5", default-features = false }
 log = { version = "0.4", default-features = false }
 log-panics = { version = "2", default-features = false }
 modemmanager = { git = "https://github.com/omnect/modemmanager.git", tag = "0.3.4", default-features = false, optional = true }
-nix = { version = "0.30", default-features = false, features = ["time"] }
 notify = { version = "8.0", default-features = false }
 notify-debouncer-full = { version = "0.5", default-features = false }
 regex-lite = { version = "0.1", default-features = true }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,11 +7,11 @@ pub mod web_service;
 
 use env_logger::{Builder, Env, Target};
 use log::{error, info};
-use std::{env, io::Write, process};
+use std::{io::Write, process};
 use twin::Twin;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> process::ExitCode {
     log_panics::init();
 
     let mut builder = if cfg!(debug_assertions) {
@@ -45,18 +45,10 @@ async fn main() {
     if let Err(e) = Twin::run().await {
         error!("application error: {e:#}");
 
-        process::exit(1);
+        process::exit(1)
     }
 
     info!("application shutdown");
 
-    // FIXME:
-    //   under some circumstances the app can hang at termination what can be
-    //   worked around by explicitly issuing exit here.
-    //   to ease further examination of that problem allow setting an
-    //   environment variable to skip the workaround.
-    if env::var("DONT_EXPLICITLY_EXIT_ON_TERMINATION").is_err() {
-        // ensure that we terminate here right now
-        process::exit(0);
-    }
+    process::exit(0)
 }

--- a/src/systemd/mod.rs
+++ b/src/systemd/mod.rs
@@ -44,6 +44,9 @@ pub async fn reboot() -> Result<()> {
         )
         .await
         .context("reboot: call_method() failed")?;
+
+    debug!("reboot: succeeded to call systemd reboot");
+
     Ok(())
 }
 

--- a/src/systemd/mod.rs
+++ b/src/systemd/mod.rs
@@ -18,12 +18,17 @@ pub fn sd_notify_ready() {
 }
 
 #[cfg(not(feature = "mock"))]
-pub async fn reboot() -> Result<()> {
+pub async fn reboot(reason: &str, extra_info: &str) -> Result<()> {
+    use crate::reboot_reason;
     use anyhow::Context;
     use log::{debug, error};
     use std::process::Command;
 
     info!("systemd::reboot");
+
+    reboot_reason::write_reboot_reason(reason, extra_info).context(format!(
+        "reboot: failed to write reason '{reason}' with info '{extra_info}'"
+    ))?;
 
     //journalctl seems not to have a dbus api
     match Command::new("sudo").args(["journalctl", "--sync"]).status() {
@@ -44,9 +49,6 @@ pub async fn reboot() -> Result<()> {
         )
         .await
         .context("reboot: call_method() failed")?;
-
-    debug!("reboot: succeeded to call systemd reboot");
-
     Ok(())
 }
 
@@ -74,6 +76,6 @@ pub async fn wait_for_system_running() -> Result<()> {
 }
 
 #[cfg(feature = "mock")]
-pub async fn reboot() -> Result<()> {
+pub async fn reboot(_reason: &str, _extra_info: &str) -> Result<()> {
     Ok(())
 }

--- a/src/twin/factory_reset.rs
+++ b/src/twin/factory_reset.rs
@@ -1,13 +1,13 @@
 use crate::{
     bootloader_env,
     common::from_json_file,
-    reboot_reason, systemd,
+    systemd,
     twin::{Feature, feature::*},
     web_service,
 };
 use anyhow::{Context, Result, bail};
 use azure_iot_sdk::client::IotMessage;
-use log::{debug, error, info, warn};
+use log::{debug, info, warn};
 use notify_debouncer_full::{Debouncer, NoCache, notify::*};
 use serde::{Deserialize, Serialize};
 use serde_json::{from_reader, json};
@@ -263,13 +263,7 @@ impl FactoryReset {
         }
 
         bootloader_env::set("factory-reset", &serde_json::to_string(&cmd)?)?;
-
-        if let Err(e) =
-            reboot_reason::write_reboot_reason("factory-reset", "initiated by portal or API")
-        {
-            error!("reset_to_factory_settings: failed to write reboot reason with {e:#}");
-        }
-        systemd::reboot().await?;
+        systemd::reboot("factory-reset", "initiated by portal or API").await?;
         Ok(None)
     }
 }

--- a/src/twin/firmware_update/update_validation.rs
+++ b/src/twin/firmware_update/update_validation.rs
@@ -1,20 +1,18 @@
 use crate::{
     bootloader_env,
-    common::{from_json_file, to_json_file, RootPartition},
+    common::{RootPartition, from_json_file, to_json_file},
     reboot_reason,
     systemd::{self, unit::UnitAction, watchdog::WatchdogManager},
     twin::{firmware_update::common::*, web_service},
 };
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use log::{debug, error, info};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use serde_with::{serde_as, DurationMilliSeconds};
 use std::{env, fs, path::Path};
 use tokio::{
     sync::oneshot,
-    task::JoinHandle,
-    time::{timeout, Duration},
+    time::{Duration, Instant, timeout_at},
 };
 
 // this file is used to detect if we have to validate an update
@@ -23,10 +21,11 @@ static UPDATE_VALIDATION_FILE: &str = "/run/omnect-device-service/omnect_validat
 static UPDATE_VALIDATION_COMPLETE_BARRIER_FILE: &str =
     "/run/omnect-device-service/omnect_validate_update_complete_barrier";
 // this file is used to determine a recovery after a failed update validation
-static UPDATE_VALIDATION_FAILED: &str = "/run/omnect-device-service/omnect_validate_update_failed";
-static UPDATE_VALIDATION_TIMEOUT_IN_SECS: u64 = 300;
+static UPDATE_VALIDATION_FAILED_FILE: &str =
+    "/run/omnect-device-service/omnect_validate_update_failed";
+static UPDATE_VALIDATION_TIMEOUT_IN_SECS_DEFAULT: u64 = 300;
 
-#[derive(Default, Serialize)]
+#[derive(Debug, Default, Serialize)]
 enum UpdateValidationStatus {
     #[default]
     NoUpdate,
@@ -35,130 +34,115 @@ enum UpdateValidationStatus {
     Succeeded,
 }
 
-#[serde_as]
+impl UpdateValidationStatus {
+    fn init() -> Self {
+        if let Ok(true) = Path::new(UPDATE_VALIDATION_COMPLETE_BARRIER_FILE).try_exists() {
+            UpdateValidationStatus::ValidatingTrial(1)
+        } else if let Ok(true) = Path::new(UPDATE_VALIDATION_FILE).try_exists() {
+            UpdateValidationStatus::ValidatingTrial(0)
+        } else if let Ok(true) = Path::new(UPDATE_VALIDATION_FAILED_FILE).try_exists() {
+            UpdateValidationStatus::Recovered
+        } else {
+            UpdateValidationStatus::NoUpdate
+        }
+    }
+}
+
 #[derive(Default, Deserialize, Serialize)]
-pub struct UpdateValidation {
-    #[serde_as(as = "DurationMilliSeconds<u64>")]
-    #[serde(rename = "start_monotonic_time_ms")]
-    start_monotonic_time: Duration,
+pub struct UpdateValidationParams {
+    start_boottime_secs: u64,
+    deadline_boottime_secs: u64,
     restart_count: u8,
     authenticated: bool,
     local_update: bool,
-    #[serde(skip)]
-    validation_timeout: Duration,
-    #[serde(skip)]
+}
+
+#[derive(Default)]
+pub struct UpdateValidation {
+    params: Option<UpdateValidationParams>,
     tx_validated: Option<oneshot::Sender<()>>,
-    #[serde(skip)]
     tx_cancel_timer: Option<oneshot::Sender<()>>,
-    #[serde(skip)]
-    join_handle: Option<JoinHandle<()>>,
-    #[serde(skip)]
     status: UpdateValidationStatus,
 }
 
 impl UpdateValidation {
     pub async fn new(tx_validated: oneshot::Sender<()>) -> Result<Self> {
-        let mut new_self = UpdateValidation::default();
-        let validation_timeout = Duration::from_secs(UPDATE_VALIDATION_TIMEOUT_IN_SECS);
-        if let Ok(timeout_secs) = env::var("UPDATE_VALIDATION_TIMEOUT_IN_SECS") {
-            match timeout_secs.parse::<u64>() {
-                Ok(timeout_secs) => {
-                    new_self.validation_timeout = Duration::from_secs(timeout_secs);
+        let new_self = match UpdateValidationStatus::init() {
+            UpdateValidationStatus::ValidatingTrial(trial) => {
+                Self::start_validation(trial == 0, tx_validated)?
+            }
+            status => {
+                if let Err(e) = tx_validated.send(()) {
+                    error!("failed to send validated state: {e:#?}")
                 }
-                _ => error!("ignore invalid confirmation timeout {timeout_secs}"),
-            };
-        }
-
-        if let Ok(true) = Path::new(UPDATE_VALIDATION_COMPLETE_BARRIER_FILE).try_exists() {
-            // we detected update validation before, but were not validated before
-            new_self = from_json_file(UPDATE_VALIDATION_COMPLETE_BARRIER_FILE)?;
-            new_self.restart_count += 1;
-            new_self.status = UpdateValidationStatus::ValidatingTrial(new_self.restart_count);
-            info!("retry start ({})", new_self.restart_count);
-            to_json_file(&new_self, UPDATE_VALIDATION_COMPLETE_BARRIER_FILE, false)?;
-            let now = Duration::from(nix::time::clock_gettime(
-                nix::time::ClockId::CLOCK_MONOTONIC,
-            )?);
-            new_self.validation_timeout =
-                validation_timeout - (now - new_self.start_monotonic_time);
-        } else if let Ok(true) = Path::new(UPDATE_VALIDATION_FILE).try_exists() {
-            info!("first start");
-            new_self.start_monotonic_time = Duration::from(nix::time::clock_gettime(
-                nix::time::ClockId::CLOCK_MONOTONIC,
-            )?);
-            // check if there is an update validation config
-            if let Ok(true) = Path::new(&update_validation_config_path!()).try_exists() {
-                let config: UpdateValidationConfig =
-                    from_json_file(update_validation_config_path!())?;
-                new_self.local_update = config.local;
-            }
-
-            to_json_file(&new_self, UPDATE_VALIDATION_COMPLETE_BARRIER_FILE, true)?;
-
-            new_self.validation_timeout = validation_timeout;
-            new_self.status = UpdateValidationStatus::ValidatingTrial(new_self.restart_count);
-        } else if let Ok(true) = Path::new(UPDATE_VALIDATION_FAILED).try_exists() {
-            info!("recovered after update validation failed");
-            new_self.status = UpdateValidationStatus::Recovered;
-            if let Err(e) = &tx_validated.send(()) {
-                error!("failed to send validated state: {e:#?}")
-            }
-            new_self.report().await;
-            return Ok(new_self);
-        } else {
-            info!("no update to be validated");
-            new_self.status = UpdateValidationStatus::NoUpdate;
-            if let Err(e) = &tx_validated.send(()) {
-                error!("failed to send validated state: {e:#?}")
-            }
-            new_self.report().await;
-            return Ok(new_self);
-        }
-
-        if matches!(new_self.status, UpdateValidationStatus::ValidatingTrial(_)) {
-            let (tx_cancel_timer, rx_cancel_timer) = oneshot::channel();
-            new_self.tx_cancel_timer = Some(tx_cancel_timer);
-            let validation_timeout = new_self.validation_timeout;
-
-            new_self.join_handle = Some(tokio::spawn(async move {
-                let timeout_ms = validation_timeout.as_millis();
-                info!("reboot timer started ({timeout_ms} ms).");
-                match timeout(validation_timeout, rx_cancel_timer).await {
-                    Err(_) => {
-                        error!("update validation timed out: write reboot reason and reboot");
-                        if let Err(e) = reboot_reason::write_reboot_reason(
-                            "swupdate-validation-failed",
-                            &format!("timer ({timeout_ms} ms) expired"),
-                        ) {
-                            error!("update validation timed out: failed to write reboot reason with {e:#}");
-                        }
-                        if let Err(e) = systemd::reboot().await {
-                            error!(
-                                "update validation timed out: failed to trigger reboot with {e:#}"
-                            );
-                        }
-                    }
-                    _ => info!("reboot timer canceled."),
+                UpdateValidation {
+                    status,
+                    ..Default::default()
                 }
-                debug!("update validation timed out: after match!");
-            }));
-        }
-        new_self.tx_validated = Some(tx_validated);
+            }
+        };
+        info!("update validation status: {:?}", new_self.status);
         new_self.report().await;
         Ok(new_self)
     }
 
+    fn start_validation(first_start: bool, tx_validated: oneshot::Sender<()>) -> Result<Self> {
+        let params = if first_start {
+            let start_boottime_secs = sysinfo::System::boot_time();
+            let deadline_boottime_secs = start_boottime_secs + Self::timeout_secs();
+
+            // check if there is an update validation config
+            let mut local_update = false;
+            if let Ok(true) = Path::new(&update_validation_config_path!()).try_exists() {
+                let config: UpdateValidationConfig =
+                    from_json_file(update_validation_config_path!())?;
+                local_update = config.local;
+            };
+
+            UpdateValidationParams {
+                start_boottime_secs,
+                deadline_boottime_secs,
+                local_update,
+                ..Default::default()
+            }
+        } else {
+            // we detected update validation before, but were not validated before
+            let mut params: UpdateValidationParams =
+                from_json_file(UPDATE_VALIDATION_COMPLETE_BARRIER_FILE)?;
+            params.restart_count += 1;
+            params
+        };
+
+        to_json_file(
+            &params,
+            UPDATE_VALIDATION_COMPLETE_BARRIER_FILE,
+            first_start,
+        )?;
+
+        let mut update_validation = UpdateValidation {
+            status: UpdateValidationStatus::ValidatingTrial(params.restart_count),
+            params: Some(params),
+            tx_validated: Some(tx_validated),
+            ..Default::default()
+        };
+
+        update_validation.start_timeout()?;
+        Ok(update_validation)
+    }
+
     pub async fn set_authenticated(&mut self, authenticated: bool) -> Result<()> {
         if matches!(self.status, UpdateValidationStatus::ValidatingTrial(_)) {
-            self.authenticated = authenticated;
+            let params = self.params.as_mut().context("validation params missing")?;
+
+            params.authenticated = authenticated;
             debug!(
                 "authenticated: {}, local update: {}",
-                self.authenticated, self.local_update
+                params.authenticated, params.local_update
             );
 
             // for local updates we accept if there is no connection to iothub
-            if self.local_update || self.authenticated {
-                to_json_file(&self, UPDATE_VALIDATION_COMPLETE_BARRIER_FILE, false)?;
+            if params.local_update || params.authenticated {
+                to_json_file(&params, UPDATE_VALIDATION_COMPLETE_BARRIER_FILE, false)?;
                 // for now start validation blocking twin::init - maybe we want an successful twin::init as part of validation at some point?
                 return self.check().await;
             }
@@ -168,9 +152,8 @@ impl UpdateValidation {
 
     async fn validate(&mut self) -> Result<()> {
         debug!("started");
-        systemd::wait_for_system_running()
-            .await
-            .context("validate: wait_for_system_running failed")?;
+
+        systemd::wait_for_system_running().await?;
 
         /* ToDo: if it returns with an error, we may want to handle the state
          * "degraded" and possibly ignore certain failed services via configuration
@@ -181,10 +164,12 @@ impl UpdateValidation {
         debug!("starting {IOT_HUB_DEVICE_UPDATE_SERVICE}");
         fs::remove_file(UPDATE_VALIDATION_FILE).context("remove UPDATE_VALIDATION_FILE")?;
 
+        let params = self.params.as_mut().context("validation params missing")?;
+
         // in case of local update we don't take care of starting deviceupdate-agent.service,
         // since it might fail because of missing iothub connection.
         // instead we let deviceupdate-agent.timer doing the job periodically
-        if !self.local_update {
+        if !params.local_update {
             systemd::unit::unit_action(
                 IOT_HUB_DEVICE_UPDATE_SERVICE,
                 UnitAction::Start,
@@ -243,8 +228,14 @@ impl UpdateValidation {
     }
 
     async fn check(&mut self) -> Result<()> {
-        // prolong watchdog interval for update validation phase
-        let saved_interval = WatchdogManager::interval(self.validation_timeout).await?;
+        // prolong watchdog interval for update validation phase by twice the remaining
+        // update cancellation timer
+        let saved_interval = WatchdogManager::interval(
+            self.remaining_timeout()?
+                .checked_mul(2)
+                .context("watchdog duration overflow")?,
+        )
+        .await?;
 
         if let Err(e) = self.validate().await {
             if let Err(e) = reboot_reason::write_reboot_reason(
@@ -280,5 +271,55 @@ impl UpdateValidation {
             json!({"status": self.status}),
         )
         .await;
+    }
+
+    fn start_timeout(&mut self) -> Result<()> {
+        let (tx_cancel_timer, rx_cancel_timer) = oneshot::channel();
+        let deadline = Instant::now() + self.remaining_timeout()?;
+        self.tx_cancel_timer = Some(tx_cancel_timer);
+        tokio::spawn(async move {
+            info!("reboot timer started");
+            match timeout_at(deadline, rx_cancel_timer).await {
+                Err(_) => {
+                    error!("update validation timed out: write reboot reason and reboot");
+                    if let Err(e) = reboot_reason::write_reboot_reason(
+                        "swupdate-validation-failed",
+                        "timer expired",
+                    ) {
+                        error!(
+                            "update validation timed out: failed to write reboot reason with {e:#}"
+                        );
+                    }
+                    if let Err(e) = systemd::reboot().await {
+                        error!("update validation timed out: failed to trigger reboot with {e:#}");
+                    }
+                }
+                _ => info!("reboot timer canceled."),
+            }
+        });
+
+        Ok(())
+    }
+
+    fn timeout_secs() -> u64 {
+        let mut timeout_secs = UPDATE_VALIDATION_TIMEOUT_IN_SECS_DEFAULT;
+        if let Ok(secs) = env::var("UPDATE_VALIDATION_TIMEOUT_IN_SECS") {
+            match secs.parse::<u64>() {
+                Ok(secs) => {
+                    timeout_secs = secs;
+                }
+                _ => error!("ignore invalid confirmation timeout {secs}"),
+            };
+        }
+        timeout_secs
+    }
+
+    fn remaining_timeout(&self) -> Result<Duration> {
+        let params = self.params.as_ref().context("validation params missing")?;
+
+        Ok(
+            Duration::from_secs(params.start_boottime_secs + Self::timeout_secs())
+                - Duration::from_secs(sysinfo::System::boot_time()),
+        )
     }
 }

--- a/src/twin/firmware_update/update_validation.rs
+++ b/src/twin/firmware_update/update_validation.rs
@@ -79,7 +79,7 @@ impl UpdateValidation {
         let params = if first_start {
             UpdateValidationParams {
                 deadline_timestamp: SystemTime::now()
-                    .checked_add(Duration::from_secs(Self::timeout_secs()))
+                    .checked_add(Self::timeout())
                     .context("failed to build deadline timestamp")?,
                 restart_count: 0,
             }
@@ -259,18 +259,19 @@ impl UpdateValidation {
         Ok(())
     }
 
-    fn timeout_secs() -> u64 {
-        let mut timeout_secs = UPDATE_VALIDATION_TIMEOUT_IN_SECS_DEFAULT;
+    fn timeout() -> Duration {
+        let mut timeout = Duration::from_secs(UPDATE_VALIDATION_TIMEOUT_IN_SECS_DEFAULT);
         if let Ok(secs) = env::var("UPDATE_VALIDATION_TIMEOUT_IN_SECS") {
             match secs.parse::<u64>() {
                 Ok(secs) => {
-                    timeout_secs = secs;
+                    timeout = Duration::from_secs(secs);
                 }
                 _ => error!(
-                    "ignore invalid confirmation timeout {secs}s and use default {timeout_secs}s"
+                    "ignore invalid confirmation timeout {secs}s and use default {}s",
+                    timeout.as_secs()
                 ),
             };
         }
-        timeout_secs
+        timeout
     }
 }

--- a/src/twin/mod.rs
+++ b/src/twin/mod.rs
@@ -422,7 +422,8 @@ impl Twin {
                 Some(_) = trigger_watchdog.next() => {
                     systemd::watchdog::WatchdogManager::notify().await?;
                 },
-                _ = signals.next() => {
+                Some(signal) = signals.next() => {
+                    info!("received termination signal: {signal:?}");
                     twin.shutdown(&mut rx_reported_properties, &mut rx_outgoing_message).await;
                     signals.handle().close();
                     return Ok(())

--- a/src/twin/mod.rs
+++ b/src/twin/mod.rs
@@ -22,12 +22,10 @@ use {
 #[cfg(not(test))]
 use azure_iot_sdk::client::{IotHubClient, IotHubClientBuilder};
 
-use crate::{systemd, twin::feature::Command, web_service};
+use crate::{systemd, twin::feature::*, web_service};
 use anyhow::{Context, Result, ensure};
 use azure_iot_sdk::client::*;
 use dotenvy;
-use feature::*;
-use firmware_update::update_validation::UpdateValidation;
 use futures::stream;
 use futures_util::StreamExt;
 use log::{error, info, warn};
@@ -41,10 +39,7 @@ use std::{
     path::Path,
     time::{self, Duration},
 };
-use tokio::{
-    select,
-    sync::{mpsc, oneshot},
-};
+use tokio::{select, sync::mpsc};
 use tokio_stream::wrappers::{IntervalStream, ReceiverStream};
 
 #[derive(PartialEq)]
@@ -60,7 +55,6 @@ pub struct Twin {
     tx_command_request: mpsc::Sender<CommandRequest>,
     tx_reported_properties: mpsc::Sender<serde_json::Value>,
     tx_outgoing_message: mpsc::Sender<IotMessage>,
-    update_validated: bool,
     state: TwinState,
     features: HashMap<TypeId, Box<DynFeature<'static>>>,
     waiting_for_reboot: bool,
@@ -71,7 +65,6 @@ impl Twin {
         tx_command_request: mpsc::Sender<CommandRequest>,
         tx_reported_properties: mpsc::Sender<serde_json::Value>,
         tx_outgoing_message: mpsc::Sender<IotMessage>,
-        tx_validated: oneshot::Sender<()>,
     ) -> Result<Self> {
         /*
             - init features first
@@ -92,9 +85,7 @@ impl Twin {
             ),
             (
                 TypeId::of::<firmware_update::FirmwareUpdate>(),
-                DynFeature::boxed(firmware_update::FirmwareUpdate::new(
-                    UpdateValidation::new(tx_validated).await?,
-                )),
+                DynFeature::boxed(firmware_update::FirmwareUpdate::new().await?),
             ),
             (
                 TypeId::of::<modem_info::ModemInfo>(),
@@ -128,7 +119,6 @@ impl Twin {
             tx_command_request,
             tx_reported_properties,
             tx_outgoing_message,
-            update_validated: false,
             state: TwinState::Uninitialized,
             features,
             waiting_for_reboot: false,
@@ -355,17 +345,13 @@ impl Twin {
     }
 
     async fn request_validate_update(&mut self, authenticated: bool) -> Result<()> {
-        if !self.update_validated {
-            self.tx_command_request
-                .send(CommandRequest {
-                    command: Command::ValidateUpdateAuthenticated(authenticated),
-                    reply: None,
-                })
-                .await
-                .context("handle_connection_status: requests receiver dropped")?;
-        };
-
-        Ok(())
+        self.tx_command_request
+            .send(CommandRequest {
+                command: Command::ValidateUpdate(authenticated),
+                reply: None,
+            })
+            .await
+            .context("request_validate_update: requests receiver dropped")
     }
 
     pub async fn run() -> Result<()> {
@@ -375,7 +361,6 @@ impl Twin {
         let (tx_reported_properties, mut rx_reported_properties) = mpsc::channel(100);
         let (tx_outgoing_message, mut rx_outgoing_message) = mpsc::channel(100);
         let (tx_command_request, rx_command_request) = mpsc::channel(100);
-        let (tx_validated, mut rx_validated) = oneshot::channel();
 
         // load env vars from /usr/lib/os-release, e.g. to determine feature availability
         dotenvy::from_path_override(
@@ -387,7 +372,6 @@ impl Twin {
             tx_command_request,
             tx_reported_properties,
             tx_outgoing_message,
-            tx_validated,
         )
         .await?;
 
@@ -447,9 +431,6 @@ impl Twin {
                         twin.reset_client_with_delay(Some(time::Duration::from_secs(1))).await;
                         client_created.set(Self::connect_iothub_client(&client_builder));
                     };
-                },
-                Ok(_) = &mut rx_validated, if !twin.update_validated => {
-                    twin.update_validated = true;
                 },
                 requests = command_requests.select_next_some(), if !twin.waiting_for_reboot => {
                     twin.handle_request(requests).await?

--- a/src/twin/mod_test.rs
+++ b/src/twin/mod_test.rs
@@ -237,13 +237,11 @@ pub mod mod_test {
             let (tx_reported_properties, mut rx_reported_properties) = mpsc::channel(100);
             let (tx_outgoing_message, _rx_outgoing_message) = mpsc::channel(100);
             let (tx_web_service, _rx_web_service) = mpsc::channel(100);
-            let (tx_validated, mut _rx_validated) = tokio::sync::oneshot::channel();
 
             let mut twin = block_on(Twin::new(
                 tx_web_service,
                 tx_reported_properties,
                 tx_outgoing_message,
-                tx_validated,
             ))
             .unwrap();
 

--- a/src/twin/reboot.rs
+++ b/src/twin/reboot.rs
@@ -1,11 +1,11 @@
 use crate::{
-    reboot_reason, systemd,
-    twin::{feature::*, Feature},
+    systemd,
+    twin::{Feature, feature::*},
     web_service,
 };
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use azure_iot_sdk::client::IotMessage;
-use log::{debug, error, info};
+use log::{debug, info};
 use serde::Deserialize;
 use serde_json::json;
 use std::{env, time::Duration};
@@ -64,13 +64,7 @@ impl Reboot {
     async fn reboot(&self) -> CommandResult {
         info!("reboot requested");
 
-        if let Err(e) =
-            reboot_reason::write_reboot_reason("ods-reboot", "initiated by portal or API")
-        {
-            error!("reboot: failed to write reboot reason [{e:#}]");
-        }
-
-        systemd::reboot().await?;
+        systemd::reboot("ods-reboot", "initiated by portal or API").await?;
 
         Ok(None)
     }

--- a/src/web_service.rs
+++ b/src/web_service.rs
@@ -369,12 +369,12 @@ impl WebService {
         info!("execute request: send {request:?}");
 
         if tx_request.send(request).await.is_err() {
-            error!("execute request: command receiver droped");
+            error!("execute request: command receiver dropped");
             return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).finish();
         }
 
         let Ok(result) = rx_reply.await else {
-            error!("execute request: command sender droped");
+            error!("execute request: command sender dropped");
             return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).finish();
         };
 

--- a/systemd/omnect-device-service.exec_stop_post.sh
+++ b/systemd/omnect-device-service.exec_stop_post.sh
@@ -13,7 +13,7 @@ function reboot() {
   dbus-send --system --print-reply --dest=org.freedesktop.login1 /org/freedesktop/login1 "org.freedesktop.login1.Manager.Reboot" boolean:true
 }
 
-# for now we only check for ods failed (EXIT_STATUS not0) and ignore SERVICE_RESULT
+# for now we only check for ods failed (EXIT_STATUS not 0) and ignore SERVICE_RESULT
 # and EXIT_CODE for the decision to reboot the system.
 # however, it does potentially make sense to reboot on certain combinations
 # even if restart_count < max_restart_count or update validation has not timed

--- a/systemd/omnect-device-service.exec_stop_post.sh
+++ b/systemd/omnect-device-service.exec_stop_post.sh
@@ -13,14 +13,14 @@ function reboot() {
   dbus-send --system --print-reply --dest=org.freedesktop.login1 /org/freedesktop/login1 "org.freedesktop.login1.Manager.Reboot" boolean:true
 }
 
-# for now we ignore SERVICE_RESULT for the decision to reboot
-# the system.
+# for now we only check for ods failed (EXIT_STATUS not0) and ignore SERVICE_RESULT
+# and EXIT_CODE for the decision to reboot the system.
 # however, it does potentially make sense to reboot on certain combinations
 # even if restart_count < max_restart_count or update validation has not timed
 # out yet. (we have to gain experience.)
 if [ -f ${barrier_json} ]; then
   # we are run during update validation and ods exited with an error
-  if [ "${EXIT_CODE}" == "exited" ] && [ "${EXIT_STATUS}" != "0" ]; then
+  if [ "${EXIT_STATUS}" != "0" ]; then
     restart_count=$(jq -r .restart_count ${barrier_json})
 
     if [ ${restart_count} -ge ${max_restart_count} ]; then

--- a/systemd/omnect-device-service.exec_stop_post.sh
+++ b/systemd/omnect-device-service.exec_stop_post.sh
@@ -9,40 +9,23 @@ echo SERVICE_RESULT=${SERVICE_RESULT}, EXIT_CODE=${EXIT_CODE}, EXIT_STATUS=${EXI
 
 function reboot() {
   echo "reboot triggered by ${script}: ${1}"
-  [ "${log_reboot_reason}" ] && \
-      /usr/sbin/omnect_reboot_reason.sh log swupdate-validation-failed "${1}"
+  /usr/sbin/omnect_reboot_reason.sh log swupdate-validation-failed "${1}"
   dbus-send --system --print-reply --dest=org.freedesktop.login1 /org/freedesktop/login1 "org.freedesktop.login1.Manager.Reboot" boolean:true
 }
 
-# reboot reason logging shall only happen if omnect-device-service exited with
-# en error
-log_reboot_reason=
-[ "${EXIT_STATUS}" = 0 ] || log_reboot_reason=1
-
-# for now we ignore SERVICE_RESULT and EXIT_STATUS for the decision to reboot
+# for now we ignore SERVICE_RESULT for the decision to reboot
 # the system.
 # however, it does potentially make sense to reboot on certain combinations
 # even if restart_count < max_restart_count or update validation has not timed
 # out yet. (we have to gain experience.)
 if [ -f ${barrier_json} ]; then
-  # we are run during update validation
-  now_boottime_secs=$(cat /proc/uptime | awk '{print $1}')
-  start_boottime_secs=$(jq -r .start_boottime_secs ${barrier_json})
-  deadline_boottime_secs=$(jq -r .deadline_boottime_secs ${barrier_json})
-  restart_count=$(jq -r .restart_count ${barrier_json})
-  authenticated=$(jq -r .authenticated ${barrier_json})
-  local_update=$(jq -r .local_update ${barrier_json})
+  # we are run during update validation and ods exited with an error
+  if [ "${EXIT_CODE}" == "exited" ] && [ "${EXIT_STATUS}" != "0" ]; then
+    restart_count=$(jq -r .restart_count ${barrier_json})
 
-  if [ ${restart_count} -ge ${max_restart_count} ]; then
-    reboot "too many restarts during update validation"
-  fi
-
-  if [ "${local_update}" =  "false" ] && [ "${authenticated}" =  "true" ]; then
-    reboot "omnect-device-service authenticated, but update validation failed"
-  fi
-
-  if [ ${now_boottime_secs} -ge ${deadline_boottime_secs} ]; then
-    reboot "update validation timeout"
+    if [ ${restart_count} -ge ${max_restart_count} ]; then
+      reboot "too many restarts during update validation"
+    fi
   fi
 elif [ -f ${update_validation_file} ]; then
   # we detected an update validation, but the barrier file was not created by omnect-device-service

--- a/systemd/omnect-device-service.exec_stop_post.sh
+++ b/systemd/omnect-device-service.exec_stop_post.sh
@@ -26,9 +26,9 @@ log_reboot_reason=
 # out yet. (we have to gain experience.)
 if [ -f ${barrier_json} ]; then
   # we are run during update validation
-  now=$(cat /proc/uptime | awk '{print $1}')
-  now_ms="${now%%\.*}$(printf %003d $((${now##*\.}*10)))"
-  update_validation_start_ms=$(jq -r .start_monotonic_time_ms ${barrier_json})
+  now_boottime_secs=$(cat /proc/uptime | awk '{print $1}')
+  start_boottime_secs=$(jq -r .start_boottime_secs ${barrier_json})
+  deadline_boottime_secs=$(jq -r .deadline_boottime_secs ${barrier_json})
   restart_count=$(jq -r .restart_count ${barrier_json})
   authenticated=$(jq -r .authenticated ${barrier_json})
   local_update=$(jq -r .local_update ${barrier_json})
@@ -41,7 +41,7 @@ if [ -f ${barrier_json} ]; then
     reboot "omnect-device-service authenticated, but update validation failed"
   fi
 
-  if [ $((${now_ms} - ${update_validation_start_ms})) -ge $((UPDATE_VALIDATION_TIMEOUT_IN_SECS * 1000)) ]; then
+  if [ ${now_boottime_secs} -ge ${deadline_boottime_secs} ]; then
     reboot "update validation timeout"
   fi
 elif [ -f ${update_validation_file} ]; then

--- a/systemd/omnect-device-service.service
+++ b/systemd/omnect-device-service.service
@@ -9,7 +9,6 @@ StartLimitIntervalSec=120
 
 [Service]
 # mandatory env var used in omnect-device-service & omnect-device-service.exec_stop_post.sh
-Environment="UPDATE_VALIDATION_TIMEOUT_IN_SECS=300"
 EnvironmentFile=-/etc/omnect/omnect-device-service.env
 Type=notify
 Restart=always

--- a/systemd/update-validation-observer.service
+++ b/systemd/update-validation-observer.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Observe update validation timer service
+ConditionPathExists=/run/omnect-device-service/omnect_validate_update
 
 [Service]
 ExecStart=/usr/bin/update-validation-observer.sh

--- a/systemd/update-validation-observer.service
+++ b/systemd/update-validation-observer.service
@@ -1,0 +1,5 @@
+[Unit]
+Description=Observe update validation timer service
+
+[Service]
+ExecStart=/usr/bin/update-validation-observer.sh

--- a/systemd/update-validation-observer.sh
+++ b/systemd/update-validation-observer.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+script=${0}
+update_validation_file="/run/omnect-device-service/omnect_validate_update"
+
+if [ -f ${update_validation_file} ]; then
+  echo "reboot triggered by ${script}"
+  /usr/sbin/omnect_reboot_reason.sh log swupdate-validation-failed "overall timeout"
+  dbus-send --system --print-reply --dest=org.freedesktop.login1 /org/freedesktop/login1 "org.freedesktop.login1.Manager.Reboot" boolean:true
+fi

--- a/systemd/update-validation-observer.timer
+++ b/systemd/update-validation-observer.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Observe update validation timer
+
+[Timer]
+OnBootSec=10min
+
+[Install]
+WantedBy=timers.target

--- a/systemd/update-validation-observer.timer
+++ b/systemd/update-validation-observer.timer
@@ -1,5 +1,6 @@
 [Unit]
 Description=Observe update validation timer
+ConditionPathExists=/run/omnect-device-service/omnect_validate_update
 
 [Timer]
 OnBootSec=10min


### PR DESCRIPTION
- splitted long `new` function into smaller functions
- update timeout and observation:
  -  as parallel `tokio::task` in omnect-device-service
  -  as systemd timer as fallback if ods timeout did not work for some reason
  - simplified deadline calculation (now + timerout)
- removed increase of watchdog time, since not needed anymore
- `omnect-device-service.exec_stop_post.sh`:
  - only reboot if ods exits with `!= 0`
  - don't check for `authenticated` anymore (done by ods)
  - don't handle timeouts since done `update-validation-observer.timer`
- removed setting timeout in  `omnect-device-service.service` since the same default exists in `update_validation.rs`
- moved reboot reason logic to reboot what it makes now mandatory for each reboot
- fixed hanging shutdown caused by detached task handle in `file_created_stream`