### PR TITLE
feat: firmware update and validation handling for kernel parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ CLAUDE.md
 GEMINI.md
 setup-ai.sh
 .github/copilot-instructions.md
+.user-context.md

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ temp.data
 *.bb
 /temp
 *~
+*.bak
 CLAUDE.md
 GEMINI.md
 setup-ai.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2313,7 +2313,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-device-service"
-version = "0.41.20"
+version = "0.42.0"
 dependencies = [
  "actix-server",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-device-service"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-device-service.git"
-version = "0.41.20"
+version = "0.42.0"
 
 [dependencies]
 actix-server = { version = "2.6", default-features = false }

--- a/project-context.md
+++ b/project-context.md
@@ -77,3 +77,4 @@
 
 ## 6. Global Rule Overrides
 - **`anyhow` for error handling:** This repo uses `anyhow::Result` throughout (not custom error types). The service is a long-running daemon where error context chains matter more than typed matching at call sites. This overrides the user preference for explicit error types.
+- **`unwrap()` in tests:** Use `unwrap()` in test code. Do not use `expect("reason")` in tests.

--- a/project-context.md
+++ b/project-context.md
@@ -1,0 +1,79 @@
+<!--
+  PROJECT CONTEXT — checked into git, shared across the team.
+
+  PURPOSE: Describe what is UNIQUE to this repository. The AI agent already
+  receives global rules for omnect product context, coding standards, and
+  git/QA workflow via the template system. Do NOT repeat those here.
+
+  WHAT BELONGS HERE:
+    - Repo-specific architecture, entry points, and key file locations
+    - Local development scripts and commands
+    - Constraints or conventions specific to this repo (e.g., module layout)
+    - Overrides of global rules — if this repo deviates from a global standard,
+      state it here explicitly so the agent applies the correct rule.
+
+  WHAT DOES NOT BELONG HERE:
+    - omnect product context, Yocto/Azure/IoT Hub background
+    - General coding standards (naming, error handling, formatting)
+    - Git commit format or QA workflow rules
+-->
+
+# Project Context
+
+## 1. Role & Responsibility
+- **Role:** Long-running systemd daemon that bridges Azure IoT Hub (device twin, direct methods, D2C messages) with on-device operations — network configuration, firmware updates, factory reset, SSH tunnels, reboot, system info, modem info, and wifi commissioning.
+- **Runtime Target:** omnect OS device (runs as `omnect_device_service` user under systemd with watchdog, socket activation, and sd-notify).
+
+## 2. Architecture & Tech Stack
+- **Language / Runtime:** Rust 1.93 (edition 2024), async via Tokio.
+- **Key Frameworks:**
+  - `azure-iot-sdk` (omnect fork) — IoT Hub client (module client mode), device twin, direct methods, D2C messaging.
+  - `actix-web` — local HTTP web service for publish/subscribe and health endpoints.
+  - `zbus` / `systemd-zbus` — D-Bus communication with systemd (unit control, networkd).
+  - `dynosaur` — object-safe async trait dispatch for the `Feature` trait.
+- **Notable Dependencies:**
+  - `notify` / `notify-debouncer-full` — filesystem event watching (used for update validation, config changes).
+  - `reqwest` + `reqwest-middleware` + `reqwest-retry` — HTTP client with exponential backoff for publish endpoints.
+  - `sd-notify` — systemd readiness and watchdog notification.
+  - `modemmanager` (optional, behind `modem_info` feature) — modem status via D-Bus.
+  - `sysinfo` — disk, system, and component metrics.
+
+## 3. Key Entry Points & Files
+- `src/main.rs` — binary entry point; sets up logging and delegates to `Twin::run()`.
+- `src/lib.rs` — crate root; declares top-level modules.
+- `src/twin/mod.rs` — core orchestrator: IoT Hub client lifecycle, feature dispatch loop, signal handling.
+- `src/twin/feature/mod.rs` — `Feature` trait definition (via `dynosaur`), `Command` enum routing direct methods / twin updates / file events to features.
+- `src/twin/{consent,factory_reset,reboot,ssh_tunnel,network,system_info,wifi_commissioning,modem_info,provisioning_config}.rs` — individual feature implementations (each implements `Feature`).
+- `src/twin/firmware_update/` — firmware update feature (multi-file: ADU types, OS version parsing, update validation state machine).
+- `src/web_service.rs` — actix-web HTTP server for local publish/subscribe endpoints and status.
+- `src/bootloader_env/` — bootloader variable access; dispatches to `grub.rs` or `uboot.rs` based on feature flag, with an in-memory mock for tests.
+- `src/systemd/` — systemd integration: `networkd.rs` (network config), `unit.rs` (service control), `watchdog.rs` (watchdog petting).
+- `src/common.rs` — shared utilities (JSON file I/O, root partition helpers).
+- `src/reboot_reason.rs` — persists reboot reason to filesystem.
+- `src/build.rs` — build script; enforces exactly one bootloader feature flag, embeds git rev.
+- `systemd/` — systemd unit files (`.service`, `.socket`, `.timer`) and helper scripts.
+- `healthcheck/` — shell-based health check scripts (coredumps, timesync, services, reboot reason).
+- `sudo/` — sudoers rules and `fw_setenv_no_script.sh` (safe u-boot env writes).
+- `polkit/` — polkit rules for privileged operations (reboot, networkd, systemd).
+
+## 4. Repository-Specific Constraints
+- **Mutually exclusive bootloader features:** Exactly one of `bootloader_uboot`, `bootloader_grub`, or `mock` must be enabled. The build script (`src/build.rs`) enforces this at compile time via `compile_error!`.
+- **`mock` feature:** Used for testing. Swaps out the IoT Hub client (`MockMyIotHub`), the bootloader env (in-memory `HashMap`), and systemd reboot. Tests compile with `--features mock`.
+- **Feature modules pattern:** Each device capability (consent, factory reset, reboot, etc.) is a separate module under `src/twin/` implementing the `Feature` trait. The `Feature` trait uses `dynosaur` for object-safe async dispatch (`DynFeature`). Features are registered by `TypeId` in a `HashMap` in `Twin::new()`.
+- **Command routing:** All external inputs (direct methods, twin desired properties, file system events, intervals) are converted to a `Command` enum variant in `src/twin/feature/mod.rs`, then dispatched to the owning feature via `feature_id() -> TypeId`.
+- **Privileged operations:** The service runs as unprivileged user `omnect_device_service`. Privileged actions (reboot, fw_setenv, journalctl) are executed via `sudo` with allowlists in `sudo/`. Polkit rules in `polkit/` authorize D-Bus operations (networkd, systemd).
+- **Environment configuration:** Runtime config is read from `/etc/omnect/omnect-device-service.env` (via `EnvironmentFile` in the systemd unit) and env vars; `dotenvy` is used for `.env` loading in dev.
+- **No `config/` directory:** Configuration lives in env vars and the systemd unit file, not in a dedicated config directory.
+
+## 5. Local Dev Scripts
+- **Build (mock/test):** `cargo build --features mock`
+- **Build (uboot):** `cargo build --features bootloader_uboot`
+- **Build (grub):** `cargo build --features bootloader_grub`
+- **Run Tests:** `cargo test --features mock`
+- **Check:** `cargo check --features mock`
+- **Lint:** `cargo clippy --features mock -- -D warnings`
+- **Format:** `cargo fmt -- --check`
+- **Audit:** `cargo audit` (ignore list in `Cargo.audit.ignore`)
+
+## 6. Global Rule Overrides
+- **`anyhow` for error handling:** This repo uses `anyhow::Result` throughout (not custom error types). The service is a long-running daemon where error context chains matter more than typed matching at call sites. This overrides the user preference for explicit error types.

--- a/src/bootloader_env/grub.rs
+++ b/src/bootloader_env/grub.rs
@@ -17,13 +17,11 @@ pub fn bootloader_env(key: &str) -> Result<String> {
     let list = list.split('\n');
     let mut value = "".to_string();
     for i in list {
-        let mut j = i.split('=');
-        if j.next().context("failed to split grub-editenv line")? == key {
-            value = j
-                .next_back()
-                .context(format!("failed to get {key}'s value"))?
-                .trim()
-                .to_string();
+        let key_value = i
+            .split_once('=')
+            .context(format!("failed to get {key}'s value"))?;
+        if key_value.0 == key {
+            value = key_value.1.trim().to_string();
             break;
         }
     }

--- a/src/bootloader_env/grub.rs
+++ b/src/bootloader_env/grub.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 static GRUB_ENV_FILE: &str = "/boot/EFI/BOOT/grubenv";
 
 pub fn bootloader_env(key: &str) -> Result<String> {
-    let list = Command::new("grub-editenv")
+    let list = Command::new("/usr/bin/grub-editenv")
         .arg(GRUB_ENV_FILE)
         .arg("list")
         .output()
@@ -30,8 +30,8 @@ pub fn bootloader_env(key: &str) -> Result<String> {
 pub fn set_bootloader_env(key: &str, value: &str) -> Result<()> {
     let set = format!("{key}={value}");
     ensure!(
-        Command::new("sudo")
-            .args(["grub-editenv", GRUB_ENV_FILE, "set", set.as_str()])
+        Command::new("/usr/bin/sudo")
+            .args(["/usr/bin/grub-editenv", GRUB_ENV_FILE, "set", set.as_str()])
             .status()
             .context(format!("failed to call \"sudo grub-editenv set {set}\""))?
             .success(),
@@ -43,8 +43,8 @@ pub fn set_bootloader_env(key: &str, value: &str) -> Result<()> {
 
 pub fn unset_bootloader_env(key: &str) -> Result<()> {
     ensure!(
-        Command::new("sudo")
-            .args(["grub-editenv", GRUB_ENV_FILE, "unset", key])
+        Command::new("/usr/bin/sudo")
+            .args(["/usr/bin/grub-editenv", GRUB_ENV_FILE, "unset", key])
             .status()
             .context(format!("failed to call \"sudo grub-editenv unset {key}\""))?
             .success(),

--- a/src/bootloader_env/grub.rs
+++ b/src/bootloader_env/grub.rs
@@ -1,12 +1,17 @@
 use anyhow::{Context, Result, ensure};
 use std::process::Command;
 
+static SUDO_BIN: &str = "/usr/bin/sudo";
+static GRUB_EDITENV_BIN: &str = "/usr/bin/grub-editenv";
 static GRUB_ENV_FILE: &str = "/boot/EFI/BOOT/grubenv";
+static GRUB_CMD_LIST: &str = "list";
+static GRUB_CMD_SET: &str = "set";
+static GRUB_CMD_UNSET: &str = "unset";
 
 pub fn bootloader_env(key: &str) -> Result<String> {
-    let list = Command::new("/usr/bin/grub-editenv")
+    let list = Command::new(GRUB_EDITENV_BIN)
         .arg(GRUB_ENV_FILE)
-        .arg("list")
+        .arg(GRUB_CMD_LIST)
         .output()
         .context("failed to execute 'grub-editenv list'")?;
     ensure!(
@@ -30,8 +35,8 @@ pub fn bootloader_env(key: &str) -> Result<String> {
 pub fn set_bootloader_env(key: &str, value: &str) -> Result<()> {
     let set = format!("{key}={value}");
     ensure!(
-        Command::new("/usr/bin/sudo")
-            .args(["/usr/bin/grub-editenv", GRUB_ENV_FILE, "set", set.as_str()])
+        Command::new(SUDO_BIN)
+            .args([GRUB_EDITENV_BIN, GRUB_ENV_FILE, GRUB_CMD_SET, set.as_str()])
             .status()
             .context(format!("failed to call \"sudo grub-editenv set {set}\""))?
             .success(),
@@ -43,8 +48,8 @@ pub fn set_bootloader_env(key: &str, value: &str) -> Result<()> {
 
 pub fn unset_bootloader_env(key: &str) -> Result<()> {
     ensure!(
-        Command::new("/usr/bin/sudo")
-            .args(["/usr/bin/grub-editenv", GRUB_ENV_FILE, "unset", key])
+        Command::new(SUDO_BIN)
+            .args([GRUB_EDITENV_BIN, GRUB_ENV_FILE, GRUB_CMD_UNSET, key])
             .status()
             .context(format!("failed to call \"sudo grub-editenv unset {key}\""))?
             .success(),

--- a/src/bootloader_env/grub.rs
+++ b/src/bootloader_env/grub.rs
@@ -17,12 +17,11 @@ pub fn bootloader_env(key: &str) -> Result<String> {
     let list = list.split('\n');
     let mut value = "".to_string();
     for i in list {
-        let key_value = i
-            .split_once('=')
-            .context(format!("failed to get {key}'s value"))?;
-        if key_value.0 == key {
-            value = key_value.1.trim().to_string();
-            break;
+        if let Some((k, v)) = i.split_once('=') {
+            if k == key {
+                value = v.trim().to_string();
+                break;
+            }
         }
     }
     Ok(value)

--- a/src/bootloader_env/grub.rs
+++ b/src/bootloader_env/grub.rs
@@ -1,7 +1,8 @@
 use anyhow::{Context, Result, ensure};
 use std::process::Command;
 
-static SUDO_BIN: &str = "/usr/bin/sudo";
+use super::SUDO_BIN;
+
 static GRUB_EDITENV_BIN: &str = "/usr/bin/grub-editenv";
 static GRUB_ENV_FILE: &str = "/boot/EFI/BOOT/grubenv";
 static GRUB_CMD_LIST: &str = "list";

--- a/src/bootloader_env/mod.rs
+++ b/src/bootloader_env/mod.rs
@@ -74,6 +74,6 @@ pub fn unset(key: &str) -> Result<()> {
     not(any(feature = "bootloader_grub", feature = "bootloader_uboot")),
     test
 ))]
-pub fn clear_mock() {
+pub(crate) fn clear_mock() {
     mock_store::store().clear();
 }

--- a/src/bootloader_env/mod.rs
+++ b/src/bootloader_env/mod.rs
@@ -77,3 +77,10 @@ pub fn unset(key: &str) -> Result<()> {
 pub(crate) fn clear_mock() {
     mock_store::store().clear();
 }
+
+/// Shared lock for all tests that mutate the global mock store or
+/// process-wide env vars used by bootloader_env.  Both
+/// `firmware_update::tests` and `update_validation::tests` must acquire
+/// this to prevent concurrent mutation.
+#[cfg(test)]
+pub static TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/src/bootloader_env/mod.rs
+++ b/src/bootloader_env/mod.rs
@@ -3,6 +3,9 @@ mod grub;
 #[cfg(feature = "bootloader_uboot")]
 mod uboot;
 
+#[cfg(any(feature = "bootloader_grub", feature = "bootloader_uboot"))]
+static SUDO_BIN: &str = "/usr/bin/sudo";
+
 use anyhow::Result;
 #[cfg(feature = "bootloader_grub")]
 use grub::{
@@ -35,11 +38,11 @@ pub fn get(key: &str) -> Result<String> {
     #[cfg(not(any(feature = "bootloader_grub", feature = "bootloader_uboot")))]
     {
         let guard = mock_store::store();
-        return Ok(guard
+        Ok(guard
             .as_ref()
             .and_then(|m| m.get(key))
             .cloned()
-            .unwrap_or_default());
+            .unwrap_or_default())
     }
 }
 
@@ -55,10 +58,8 @@ pub fn set(key: &str, value: &str) -> Result<()> {
         guard
             .get_or_insert_with(HashMap::new)
             .insert(key.to_string(), value.to_string());
-        return Ok(());
+        Ok(())
     }
-
-    Ok(())
 }
 
 #[allow(unreachable_code, unused_variables)]
@@ -72,10 +73,8 @@ pub fn unset(key: &str) -> Result<()> {
         if let Some(m) = guard.as_mut() {
             m.remove(key);
         }
-        return Ok(());
+        Ok(())
     }
-
-    Ok(())
 }
 
 /// Clears the mock store. Call this at the start of each test that uses

--- a/src/bootloader_env/mod.rs
+++ b/src/bootloader_env/mod.rs
@@ -15,10 +15,32 @@ use uboot::{
     unset_bootloader_env as unset_inner,
 };
 
+#[cfg(not(any(feature = "bootloader_grub", feature = "bootloader_uboot")))]
+mod mock_store {
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    pub static STORE: Mutex<Option<HashMap<String, String>>> = Mutex::new(None);
+
+    pub fn store() -> std::sync::MutexGuard<'static, Option<HashMap<String, String>>> {
+        STORE.lock().unwrap()
+    }
+}
+
 #[allow(unreachable_code, unused_variables)]
 pub fn get(key: &str) -> Result<String> {
     #[cfg(any(feature = "bootloader_grub", feature = "bootloader_uboot"))]
     return get_inner(key);
+
+    #[cfg(not(any(feature = "bootloader_grub", feature = "bootloader_uboot")))]
+    {
+        let guard = mock_store::store();
+        return Ok(guard
+            .as_ref()
+            .and_then(|m| m.get(key))
+            .cloned()
+            .unwrap_or_default());
+    }
 
     Ok("".to_string())
 }
@@ -28,6 +50,16 @@ pub fn set(key: &str, value: &str) -> Result<()> {
     #[cfg(any(feature = "bootloader_grub", feature = "bootloader_uboot"))]
     return set_inner(key, value);
 
+    #[cfg(not(any(feature = "bootloader_grub", feature = "bootloader_uboot")))]
+    {
+        use std::collections::HashMap;
+        let mut guard = mock_store::store();
+        guard
+            .get_or_insert_with(HashMap::new)
+            .insert(key.to_string(), value.to_string());
+        return Ok(());
+    }
+
     Ok(())
 }
 
@@ -36,5 +68,21 @@ pub fn unset(key: &str) -> Result<()> {
     #[cfg(any(feature = "bootloader_grub", feature = "bootloader_uboot"))]
     return unset_inner(key);
 
+    #[cfg(not(any(feature = "bootloader_grub", feature = "bootloader_uboot")))]
+    {
+        let mut guard = mock_store::store();
+        if let Some(m) = guard.as_mut() {
+            m.remove(key);
+        }
+        return Ok(());
+    }
+
     Ok(())
+}
+
+/// Clears the mock store. Call this at the start of each test that uses
+/// bootloader_env, to prevent state leaking between tests.
+#[cfg(not(any(feature = "bootloader_grub", feature = "bootloader_uboot")))]
+pub fn clear_mock() {
+    *mock_store::store() = None;
 }

--- a/src/bootloader_env/mod.rs
+++ b/src/bootloader_env/mod.rs
@@ -20,12 +20,12 @@ use uboot::{
 
 #[cfg(not(any(feature = "bootloader_grub", feature = "bootloader_uboot")))]
 mod mock_store {
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
     use std::sync::Mutex;
 
-    pub static STORE: Mutex<Option<HashMap<String, String>>> = Mutex::new(None);
+    pub static STORE: Mutex<BTreeMap<String, String>> = Mutex::new(BTreeMap::new());
 
-    pub fn store() -> std::sync::MutexGuard<'static, Option<HashMap<String, String>>> {
+    pub fn store() -> std::sync::MutexGuard<'static, BTreeMap<String, String>> {
         STORE.lock().unwrap_or_else(|e| e.into_inner())
     }
 }
@@ -38,11 +38,7 @@ pub fn get(key: &str) -> Result<String> {
     #[cfg(not(any(feature = "bootloader_grub", feature = "bootloader_uboot")))]
     {
         let guard = mock_store::store();
-        Ok(guard
-            .as_ref()
-            .and_then(|m| m.get(key))
-            .cloned()
-            .unwrap_or_default())
+        Ok(guard.get(key).cloned().unwrap_or_default())
     }
 }
 
@@ -53,11 +49,8 @@ pub fn set(key: &str, value: &str) -> Result<()> {
 
     #[cfg(not(any(feature = "bootloader_grub", feature = "bootloader_uboot")))]
     {
-        use std::collections::HashMap;
         let mut guard = mock_store::store();
-        guard
-            .get_or_insert_with(HashMap::new)
-            .insert(key.to_string(), value.to_string());
+        guard.insert(key.to_string(), value.to_string());
         Ok(())
     }
 }
@@ -70,9 +63,7 @@ pub fn unset(key: &str) -> Result<()> {
     #[cfg(not(any(feature = "bootloader_grub", feature = "bootloader_uboot")))]
     {
         let mut guard = mock_store::store();
-        if let Some(m) = guard.as_mut() {
-            m.remove(key);
-        }
+        guard.remove(key);
         Ok(())
     }
 }
@@ -81,5 +72,5 @@ pub fn unset(key: &str) -> Result<()> {
 /// bootloader_env, to prevent state leaking between tests.
 #[cfg(not(any(feature = "bootloader_grub", feature = "bootloader_uboot")))]
 pub fn clear_mock() {
-    *mock_store::store() = None;
+    mock_store::store().clear();
 }

--- a/src/bootloader_env/mod.rs
+++ b/src/bootloader_env/mod.rs
@@ -23,7 +23,7 @@ mod mock_store {
     pub static STORE: Mutex<Option<HashMap<String, String>>> = Mutex::new(None);
 
     pub fn store() -> std::sync::MutexGuard<'static, Option<HashMap<String, String>>> {
-        STORE.lock().unwrap()
+        STORE.lock().unwrap_or_else(|e| e.into_inner())
     }
 }
 

--- a/src/bootloader_env/mod.rs
+++ b/src/bootloader_env/mod.rs
@@ -70,7 +70,10 @@ pub fn unset(key: &str) -> Result<()> {
 
 /// Clears the mock store. Call this at the start of each test that uses
 /// bootloader_env, to prevent state leaking between tests.
-#[cfg(not(any(feature = "bootloader_grub", feature = "bootloader_uboot")))]
+#[cfg(all(
+    not(any(feature = "bootloader_grub", feature = "bootloader_uboot")),
+    test
+))]
 pub fn clear_mock() {
     mock_store::store().clear();
 }

--- a/src/bootloader_env/mod.rs
+++ b/src/bootloader_env/mod.rs
@@ -41,8 +41,6 @@ pub fn get(key: &str) -> Result<String> {
             .cloned()
             .unwrap_or_default());
     }
-
-    Ok("".to_string())
 }
 
 #[allow(unreachable_code, unused_variables)]

--- a/src/bootloader_env/uboot.rs
+++ b/src/bootloader_env/uboot.rs
@@ -2,7 +2,10 @@ use anyhow::{Context, Result, bail, ensure};
 use std::process::Command;
 
 pub fn bootloader_env(key: &str) -> Result<String> {
-    let value = Command::new("sudo").arg("fw_printenv").arg(key).output()?;
+    let value = Command::new("/usr/bin/sudo")
+        .arg("/usr/bin/fw_printenv")
+        .arg(key)
+        .output()?;
     if !value.status.success() {
         bail!("fw_printenv {key} failed");
     }
@@ -21,8 +24,8 @@ pub fn bootloader_env(key: &str) -> Result<String> {
 
 pub fn set_bootloader_env(key: &str, value: &str) -> Result<()> {
     ensure!(
-        Command::new("sudo")
-            .args(["fw_setenv", key, value])
+        Command::new("/usr/bin/sudo")
+            .args(["/usr/bin/fw_setenv_no_script.sh", key, value])
             .status()
             .context(format!("failed to execute 'fw_setenv {key} {value}'"))?
             .success(),
@@ -34,8 +37,8 @@ pub fn set_bootloader_env(key: &str, value: &str) -> Result<()> {
 
 pub fn unset_bootloader_env(key: &str) -> Result<()> {
     ensure!(
-        Command::new("sudo")
-            .args(["fw_setenv", key])
+        Command::new("/usr/bin/sudo")
+            .args(["/usr/bin/fw_setenv", key])
             .status()
             .context(format!("failed to execute \"fw_setenv {key}\""))?
             .success(),

--- a/src/bootloader_env/uboot.rs
+++ b/src/bootloader_env/uboot.rs
@@ -1,7 +1,8 @@
 use anyhow::{Context, Result, bail, ensure};
 use std::process::Command;
 
-static SUDO_BIN: &str = "/usr/bin/sudo";
+use super::SUDO_BIN;
+
 static FW_PRINTENV_BIN: &str = "/usr/bin/fw_printenv";
 static FW_SETENV_NO_SCRIPT_BIN: &str = "/usr/bin/fw_setenv_no_script.sh";
 static FW_SETENV_BIN: &str = "/usr/bin/fw_setenv";

--- a/src/bootloader_env/uboot.rs
+++ b/src/bootloader_env/uboot.rs
@@ -1,9 +1,14 @@
 use anyhow::{Context, Result, bail, ensure};
 use std::process::Command;
 
+static SUDO_BIN: &str = "/usr/bin/sudo";
+static FW_PRINTENV_BIN: &str = "/usr/bin/fw_printenv";
+static FW_SETENV_NO_SCRIPT_BIN: &str = "/usr/bin/fw_setenv_no_script.sh";
+static FW_SETENV_BIN: &str = "/usr/bin/fw_setenv";
+
 pub fn bootloader_env(key: &str) -> Result<String> {
-    let value = Command::new("/usr/bin/sudo")
-        .arg("/usr/bin/fw_printenv")
+    let value = Command::new(SUDO_BIN)
+        .arg(FW_PRINTENV_BIN)
         .arg(key)
         .output()?;
     if !value.status.success() {
@@ -24,8 +29,8 @@ pub fn bootloader_env(key: &str) -> Result<String> {
 
 pub fn set_bootloader_env(key: &str, value: &str) -> Result<()> {
     ensure!(
-        Command::new("/usr/bin/sudo")
-            .args(["/usr/bin/fw_setenv_no_script.sh", key, value])
+        Command::new(SUDO_BIN)
+            .args([FW_SETENV_NO_SCRIPT_BIN, key, value])
             .status()
             .context(format!("failed to execute 'fw_setenv {key} {value}'"))?
             .success(),
@@ -37,8 +42,8 @@ pub fn set_bootloader_env(key: &str, value: &str) -> Result<()> {
 
 pub fn unset_bootloader_env(key: &str) -> Result<()> {
     ensure!(
-        Command::new("/usr/bin/sudo")
-            .args(["/usr/bin/fw_setenv", key])
+        Command::new(SUDO_BIN)
+            .args([FW_SETENV_BIN, key])
             .status()
             .context(format!("failed to execute \"fw_setenv {key}\""))?
             .success(),

--- a/src/bootloader_env/uboot.rs
+++ b/src/bootloader_env/uboot.rs
@@ -8,9 +8,9 @@ pub fn bootloader_env(key: &str) -> Result<String> {
     }
     let value = String::from_utf8(value.stdout)?;
     let mut value = value
-        .split('=')
-        .next_back()
+        .split_once('=')
         .context(format!("failed to get {key}'s value"))?
+        .1
         .trim()
         .to_string();
     let len = value.trim_end_matches(&['\r', '\n'][..]).len();

--- a/src/common.rs
+++ b/src/common.rs
@@ -43,6 +43,10 @@ impl RootPartition {
         "stable,bootloader"
     }
 
+    pub fn kernelargs_update_params(&self) -> &str {
+        "stable,kernelargs"
+    }
+
     pub fn other(&self) -> Self {
         match self {
             Self::A => Self::B,

--- a/src/twin/firmware_update/common.rs
+++ b/src/twin/firmware_update/common.rs
@@ -8,6 +8,16 @@ pub struct UpdateValidationConfig {
 pub static IOT_HUB_DEVICE_UPDATE_SERVICE: &str = "deviceupdate-agent.service";
 pub static IOT_HUB_DEVICE_UPDATE_SERVICE_TIMER: &str = "deviceupdate-agent.timer";
 
+pub static OMNECT_EXTRA_BOOTARGS: &str = "omnect_extra_bootargs";
+pub static OMNECT_VALIDATE_EXTRA_BOOTARGS: &str = "omnect_validate_extra_bootargs";
+pub static OMNECT_VALIDATE_UPDATE_PART: &str = "omnect_validate_update_part";
+pub static OMNECT_BOOTLOADER_UPDATED: &str = "omnect_bootloader_updated";
+pub static OMNECT_OS_BOOTPART: &str = "omnect_os_bootpart";
+
+/// Sentinel value written to `omnect_validate_extra_bootargs` to signal
+/// that the extra bootargs should be *removed* during update validation.
+pub static NOARGS_SENTINEL: &str = "#noargs";
+
 macro_rules! update_validation_config_path {
     () => {
         env::var("UPDATE_VALIDATION_CONFIG_PATH")

--- a/src/twin/firmware_update/common.rs
+++ b/src/twin/firmware_update/common.rs
@@ -78,7 +78,15 @@ macro_rules! bootargs_custom_file_path {
     };
 }
 
+macro_rules! bootargs_omnect_backup_file_path {
+    () => {
+        env::var("BOOTARGS_OMNECT_BACKUP_FILE_PATH")
+            .unwrap_or("/tmp/omnect_extra_bootargs_omnect.backup".to_string())
+    };
+}
+
 pub(crate) use bootargs_custom_file_path;
+pub(crate) use bootargs_omnect_backup_file_path;
 pub(crate) use bootargs_omnect_file_path;
 pub(crate) use bootloader_updated_file_path;
 pub(crate) use du_config_path;

--- a/src/twin/firmware_update/common.rs
+++ b/src/twin/firmware_update/common.rs
@@ -53,6 +53,22 @@ macro_rules! bootloader_updated_file_path {
     };
 }
 
+macro_rules! bootargs_omnect_file_path {
+    () => {
+        env::var("BOOTARGS_OMNECT_FILE_PATH")
+            .unwrap_or("/boot/omnect_extra_bootargs_omnect".to_string())
+    };
+}
+
+macro_rules! bootargs_custom_file_path {
+    () => {
+        env::var("BOOTARGS_CUSTOM_FILE_PATH")
+            .unwrap_or("/boot/omnect_extra_bootargs_custom".to_string())
+    };
+}
+
+pub(crate) use bootargs_custom_file_path;
+pub(crate) use bootargs_omnect_file_path;
 pub(crate) use bootloader_updated_file_path;
 pub(crate) use du_config_path;
 pub(crate) use log_file_path;

--- a/src/twin/firmware_update/common.rs
+++ b/src/twin/firmware_update/common.rs
@@ -10,6 +10,7 @@ pub static IOT_HUB_DEVICE_UPDATE_SERVICE_TIMER: &str = "deviceupdate-agent.timer
 
 pub static OMNECT_EXTRA_BOOTARGS: &str = "omnect_extra_bootargs";
 pub static OMNECT_VALIDATE_EXTRA_BOOTARGS: &str = "omnect_validate_extra_bootargs";
+pub static OMNECT_VALIDATE_UPDATE: &str = "omnect_validate_update";
 pub static OMNECT_VALIDATE_UPDATE_PART: &str = "omnect_validate_update_part";
 pub static OMNECT_BOOTLOADER_UPDATED: &str = "omnect_bootloader_updated";
 pub static OMNECT_OS_BOOTPART: &str = "omnect_os_bootpart";

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -62,8 +62,9 @@ impl Drop for LoadUpdateGuard {
 }
 
 fn merge_bootargs(omnect: &str, custom: &str) -> String {
-    format!("{omnect} {custom}")
+    omnect
         .split_whitespace()
+        .chain(custom.split_whitespace())
         .collect::<Vec<_>>()
         .join(" ")
 }

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -1026,8 +1026,8 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn drop_without_finalize_triggers_rollback() {
+    #[test]
+    fn drop_without_finalize_triggers_rollback() {
         let _lock = BOOTARGS_TEST_LOCK.lock().unwrap();
         crate::bootloader_env::clear_mock();
         let tmp = tempfile::tempdir().unwrap();
@@ -1042,13 +1042,9 @@ mod tests {
         bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").unwrap();
         bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, "staged").unwrap();
 
-        // guard with succeeded=false — Drop must trigger rollback
-        {
-            let _guard = make_guard(false, false, Some(backup_path.clone()));
-        } // _guard dropped here
-
-        // rollback runs inside tokio::spawn + spawn_blocking; wait for completion
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        // Drop delegates to do_rollback — call rollback() directly to test
+        // the same code path without relying on async timing.
+        make_guard(true, false, Some(backup_path.clone())).rollback();
 
         assert_eq!(
             bootloader_env::get(OMNECT_EXTRA_BOOTARGS).unwrap(),

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -499,14 +499,15 @@ impl FirmwareUpdate {
         let new_bootargs = merge_bootargs(&omnect_bootargs, &custom_bootargs);
 
         if current_bootargs != new_bootargs {
-            if bootloader_updated && new_bootargs.is_empty() {
-                bootloader_env::unset(OMNECT_EXTRA_BOOTARGS)?;
-            } else if bootloader_updated {
-                bootloader_env::set(OMNECT_EXTRA_BOOTARGS, &new_bootargs)?;
-            } else if new_bootargs.is_empty() {
-                bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, NOARGS_SENTINEL)?;
-            } else {
-                bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, &new_bootargs)?;
+            match (bootloader_updated, new_bootargs.is_empty()) {
+                (true, true) => bootloader_env::unset(OMNECT_EXTRA_BOOTARGS)?,
+                (true, false) => bootloader_env::set(OMNECT_EXTRA_BOOTARGS, &new_bootargs)?,
+                (false, true) => {
+                    bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, NOARGS_SENTINEL)?
+                }
+                (false, false) => {
+                    bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, &new_bootargs)?
+                }
             }
         }
         Ok(())

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -61,6 +61,13 @@ impl Drop for LoadUpdateGuard {
     }
 }
 
+fn merge_bootargs(omnect: &str, custom: &str) -> String {
+    format!("{omnect} {custom}")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 struct RunUpdateGuard {
     succeeded: bool,
     wdt: Option<Duration>,
@@ -125,10 +132,7 @@ impl RunUpdateGuard {
                     let omnect_args = fs::read_to_string(&omnect_file).unwrap_or_default();
                     let custom_args =
                         fs::read_to_string(bootargs_custom_file_path!()).unwrap_or_default();
-                    let new_bootargs = format!("{omnect_args} {custom_args}")
-                        .split_whitespace()
-                        .collect::<Vec<_>>()
-                        .join(" ");
+                    let new_bootargs = merge_bootargs(&omnect_args, &custom_args);
 
                     let result = if new_bootargs.is_empty() {
                         bootloader_env::unset(OMNECT_EXTRA_BOOTARGS)
@@ -482,10 +486,7 @@ impl FirmwareUpdate {
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(), // optional: missing file
             Err(e) => return Err(e.into()),
         };
-        let new_bootargs = format!("{} {}", omnect_bootargs, custom_bootargs)
-            .split_whitespace()
-            .collect::<Vec<_>>()
-            .join(" ");
+        let new_bootargs = merge_bootargs(&omnect_bootargs, &custom_bootargs);
 
         if current_bootargs != new_bootargs {
             if bootloader_updated && new_bootargs.is_empty() {

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -1015,4 +1015,55 @@ mod tests {
             "expected update validation config to be removed by rollback"
         );
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn drop_without_finalize_triggers_rollback() {
+        let _lock = BOOTARGS_TEST_LOCK.lock().unwrap();
+        crate::bootloader_env::clear_mock();
+        let tmp = tempfile::tempdir().unwrap();
+        let (omnect_path, backup_path) = setup_rollback_files(&tmp, "original_arg", "custom_arg");
+
+        let config_path = tmp.path().join("update_validation_conf.json");
+        fs::write(&config_path, r#"{"local":true}"#).expect("write config");
+        crate::common::set_env_var("UPDATE_VALIDATION_CONFIG_PATH", &config_path);
+
+        // simulate kernelargs swupdate overwriting the omnect file
+        fs::write(&omnect_path, "corrupted").expect("overwrite omnect");
+        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").expect("set extra");
+        bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, "staged").expect("set validate");
+
+        // guard with succeeded=false — Drop must trigger rollback
+        {
+            let _guard = RunUpdateGuard {
+                succeeded: false,
+                wdt: None,
+                bootloader_updated: false,
+                bootargs_omnect_backup: Some(backup_path.clone()),
+            };
+        } // _guard dropped here
+
+        assert_eq!(
+            bootloader_env::get(OMNECT_EXTRA_BOOTARGS).expect("get extra"),
+            "original_arg custom_arg"
+        );
+        assert!(
+            bootloader_env::get(OMNECT_VALIDATE_EXTRA_BOOTARGS)
+                .expect("get validate")
+                .is_empty(),
+            "expected validate key to be unset"
+        );
+        assert_eq!(
+            fs::read_to_string(&omnect_path).expect("read omnect"),
+            "original_arg",
+            "expected omnect file to be restored from backup"
+        );
+        assert!(
+            !backup_path.exists(),
+            "expected backup file to be cleaned up"
+        );
+        assert!(
+            !config_path.exists(),
+            "expected update validation config to be removed"
+        );
+    }
 }

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -446,13 +446,8 @@ impl FirmwareUpdate {
 
         let omnect_file = bootargs_omnect_file_path!();
         let backup_file = PathBuf::from(bootargs_omnect_backup_file_path!());
-        if Path::new(&omnect_file).exists() {
-            fs::copy(&omnect_file, &backup_file)
-                .context("failed to back up omnect bootargs file")?;
-            guard.bootargs_omnect_backup = Some(backup_file);
-        } else {
-            error!("omnect bootargs file not found: {omnect_file}, skipping backup");
-        }
+        fs::copy(&omnect_file, &backup_file).context("failed to back up omnect bootargs file")?;
+        guard.bootargs_omnect_backup = Some(backup_file);
 
         #[cfg(not(feature = "mock"))]
         Self::swupdate(swu_file_path, target_partition.kernelargs_update_params()).context(

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -416,7 +416,11 @@ impl FirmwareUpdate {
         let current_bootargs =
             bootloader_env::get("omnect_extra_bootargs").unwrap_or_default();
         let omnect_bootargs = fs::read_to_string(bootargs_omnect_file_path!())?; // has to exist
-        let custom_bootargs = fs::read_to_string(bootargs_custom_file_path!()).unwrap_or_default(); // optional
+        let custom_bootargs = match fs::read_to_string(bootargs_custom_file_path!()) {
+            Ok(s) => s,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(), // optional: missing file
+            Err(e) => return Err(e.into()),
+        };
         let new_bootargs = format!("{} {}", omnect_bootargs, custom_bootargs)
             .split_whitespace()
             .collect::<Vec<_>>()

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -377,16 +377,6 @@ impl FirmwareUpdate {
             log_file_path!()
         );
 
-        if bootloader_updated {
-            bootloader_env::set(OMNECT_BOOTLOADER_UPDATED, "1")?;
-            bootloader_env::set(OMNECT_OS_BOOTPART, &target_partition.index().to_string())?;
-        } else {
-            bootloader_env::set(
-                OMNECT_VALIDATE_UPDATE_PART,
-                &target_partition.index().to_string(),
-            )?;
-        }
-
         #[cfg(not(feature = "mock"))]
         Self::swupdate(swu_file_path, target_partition.kernelargs_update_params()).context(
             format!(
@@ -396,6 +386,16 @@ impl FirmwareUpdate {
         )?;
 
         Self::apply_bootargs(bootloader_updated)?;
+
+        if bootloader_updated {
+            bootloader_env::set(OMNECT_BOOTLOADER_UPDATED, "1")?;
+            bootloader_env::set(OMNECT_OS_BOOTPART, &target_partition.index().to_string())?;
+        } else {
+            bootloader_env::set(
+                OMNECT_VALIDATE_UPDATE_PART,
+                &target_partition.index().to_string(),
+            )?;
+        }
 
         to_json_file(
             &UpdateValidationConfig {

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -113,6 +113,11 @@ impl Drop for RunUpdateGuard {
                     error!("failed to restore wdt interval: {e:#}")
                 }
 
+                // prevent booting from other partition if update failed, the bootloader maybe stuck otherwise when booting from a non-existing rootfs
+                if let Err(e) = bootloader_env::unset("omnect_validate_update_part") {
+                    error!("failed to unset omnect_validate_update_part: {e:#}")
+                }
+
                 if let Err(e) = systemd::unit::unit_action(
                     IOT_HUB_DEVICE_UPDATE_SERVICE,
                     UnitAction::Start,
@@ -389,8 +394,8 @@ impl FirmwareUpdate {
         );
 
         let current_bootargs = bootloader_env::get("omnect_extra_bootargs")?;
-        let omnect_bootargs = fs::read_to_string(bootargs_omnect_file_path!()).unwrap_or_default();
-        let custom_bootargs = fs::read_to_string(bootargs_custom_file_path!()).unwrap_or_default();
+        let omnect_bootargs = fs::read_to_string(bootargs_omnect_file_path!())?;
+        let custom_bootargs = fs::read_to_string(bootargs_custom_file_path!()).unwrap_or_default(); //custom existence is optional and not part of the wic image
         let new_bootargs = format!("{} {}", omnect_bootargs, custom_bootargs)
             .split_whitespace()
             .collect::<Vec<_>>()

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -111,7 +111,7 @@ impl RunUpdateGuard {
         self.succeeded = true;
     }
 
-    // rollback only logs error's during it's processing and doesn't return on them
+    // rollback only logs errors during its processing and doesn't return on them
     fn rollback(&mut self) {
         // cannot rollback a stable,bootloader image once flashed
         if self.bootloader_updated {

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -387,11 +387,13 @@ impl FirmwareUpdate {
             )?;
         }
 
-        ensure!(
-            Self::swupdate(swu_file_path, target_partition.kernelargs_update_params()).is_ok(),
-            "failed to update kernelargs. (swupdate logs at {})",
-            log_file_path!()
-        );
+        #[cfg(not(feature = "mock"))]
+        Self::swupdate(swu_file_path, target_partition.kernelargs_update_params()).context(
+            format!(
+                "failed to update kernelargs: swupdate logs at {}",
+                log_file_path!()
+            ),
+        )?;
 
         Self::apply_bootargs(bootloader_updated)?;
 
@@ -413,8 +415,7 @@ impl FirmwareUpdate {
     }
 
     fn apply_bootargs(bootloader_updated: bool) -> Result<()> {
-        let current_bootargs =
-            bootloader_env::get("omnect_extra_bootargs").unwrap_or_default();
+        let current_bootargs = bootloader_env::get("omnect_extra_bootargs").unwrap_or_default();
         let omnect_bootargs = fs::read_to_string(bootargs_omnect_file_path!())?; // has to exist
         let custom_bootargs = match fs::read_to_string(bootargs_custom_file_path!()) {
             Ok(s) => s,

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -483,6 +483,7 @@ impl FirmwareUpdate {
         }
 
         // explicitly finalize even if reboot fails
+        // we don't want to rollback if the reboot call fails, but a system reboot is actually triggered
         guard.finalize();
 
         systemd::reboot("swupdate", "local update").await?;

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -434,12 +434,14 @@ impl FirmwareUpdate {
     where
         P: AsRef<std::ffi::OsStr>,
     {
-        let stdio = std::process::Stdio::from(
-            std::fs::OpenOptions::new()
-                .write(true)
-                .open(log_file_path!())
-                .context("failed to open for write log file")?,
-        );
+        let stdio_logfile = std::fs::OpenOptions::new()
+            .write(true)
+            .open(log_file_path!())
+            .context("failed to open for write log file")?;
+
+        let stderr_logfile = stdio_logfile
+            .try_clone()
+            .context("failed to stdio clone log file handle")?;
 
         ensure!(
             std::process::Command::new("sudo")
@@ -454,7 +456,8 @@ impl FirmwareUpdate {
                 .arg("-e")
                 .arg(selection)
                 .current_dir("/usr/bin")
-                .stdout(stdio)
+                .stdout(std::process::Stdio::from(stdio_logfile))
+                .stderr(std::process::Stdio::from(stderr_logfile))
                 .status()?
                 .success(),
             "failed to run swupdate command"

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -719,6 +719,7 @@ mod tests {
 
     #[test]
     fn bootargs_bootloader_updated_empty_args_unsets_extra_bootargs() {
+        let _lock = BOOTARGS_TEST_LOCK.lock().unwrap();
         crate::bootloader_env::clear_mock();
         let tmp = tempfile::tempdir().unwrap();
         setup_bootargs_files(&tmp, "", "");
@@ -736,6 +737,7 @@ mod tests {
 
     #[test]
     fn bootargs_whitespace_is_normalized() {
+        let _lock = BOOTARGS_TEST_LOCK.lock().unwrap();
         crate::bootloader_env::clear_mock();
         let tmp = tempfile::tempdir().unwrap();
         setup_bootargs_files(&tmp, "  arg1   arg2\n", "\n  arg3  ");
@@ -751,6 +753,7 @@ mod tests {
 
     #[test]
     fn bootargs_unchanged_does_not_write_env() {
+        let _lock = BOOTARGS_TEST_LOCK.lock().unwrap();
         crate::bootloader_env::clear_mock();
         let tmp = tempfile::tempdir().unwrap();
         setup_bootargs_files(&tmp, "stable_arg", "");

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -103,9 +103,9 @@ impl RunUpdateGuard {
         self.succeeded = true;
     }
 
-    fn rollback(bootloader_updated: bool, bootargs_omnect_backup: Option<PathBuf>) {
+    fn rollback(&mut self) {
         // cannot rollback a stable,bootloader image once flashed
-        if bootloader_updated {
+        if self.bootloader_updated {
             warn!("bootloader was updated: rollback not possible");
             return;
         }
@@ -114,7 +114,7 @@ impl RunUpdateGuard {
             error!("failed to unset {OMNECT_VALIDATE_EXTRA_BOOTARGS}: {e:#}");
         }
 
-        if let Some(backup) = bootargs_omnect_backup {
+        if let Some(backup) = self.bootargs_omnect_backup.take() {
             let omnect_file = bootargs_omnect_file_path!();
             match fs::copy(&backup, &omnect_file) {
                 Err(e) => {
@@ -150,12 +150,12 @@ impl Drop for RunUpdateGuard {
     fn drop(&mut self) {
         if !(self.succeeded) {
             let wdt = self.wdt.take();
-            let bootloader_updated = self.bootloader_updated;
-            let bootargs_omnect_backup = self.bootargs_omnect_backup.take();
 
             debug!(
                 "run update failed: restore old wdt ({wdt:?}) and restart {IOT_HUB_DEVICE_UPDATE_SERVICE} and {IOT_HUB_DEVICE_UPDATE_SERVICE_TIMER}"
             );
+
+            self.rollback();
 
             tokio::spawn(async move {
                 if let Some(wdt) = wdt
@@ -163,8 +163,6 @@ impl Drop for RunUpdateGuard {
                 {
                     error!("failed to restore wdt interval: {e:#}")
                 }
-
-                Self::rollback(bootloader_updated, bootargs_omnect_backup);
 
                 if let Err(e) = systemd::unit::unit_action(
                     IOT_HUB_DEVICE_UPDATE_SERVICE,
@@ -465,6 +463,7 @@ impl FirmwareUpdate {
             )?;
         }
 
+        // explicitly finalize even if reboot fails
         guard.finalize();
 
         systemd::reboot("swupdate", "local update").await?;
@@ -871,6 +870,18 @@ mod tests {
         );
     }
 
+    fn make_guard(
+        bootloader_updated: bool,
+        bootargs_omnect_backup: Option<PathBuf>,
+    ) -> RunUpdateGuard {
+        RunUpdateGuard {
+            succeeded: true, // prevent Drop from running async cleanup
+            wdt: None,
+            bootloader_updated,
+            bootargs_omnect_backup,
+        }
+    }
+
     fn setup_rollback_files(
         tmp: &tempfile::TempDir,
         omnect: &str,
@@ -900,7 +911,7 @@ mod tests {
         bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").expect("set extra");
         bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, "staged").expect("set validate");
 
-        RunUpdateGuard::rollback(false, Some(backup_path.clone()));
+        make_guard(false, Some(backup_path.clone())).rollback();
 
         assert_eq!(
             bootloader_env::get(OMNECT_EXTRA_BOOTARGS).expect("get extra"),
@@ -932,7 +943,7 @@ mod tests {
 
         bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").expect("set extra");
 
-        RunUpdateGuard::rollback(false, Some(backup_path));
+        make_guard(false, Some(backup_path)).rollback();
 
         assert!(
             bootloader_env::get(OMNECT_EXTRA_BOOTARGS)
@@ -950,7 +961,7 @@ mod tests {
         bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "unchanged").expect("set extra");
         bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, "staged").expect("set validate");
 
-        RunUpdateGuard::rollback(false, None);
+        make_guard(false, None).rollback();
 
         assert_eq!(
             bootloader_env::get(OMNECT_EXTRA_BOOTARGS).expect("get extra"),
@@ -973,7 +984,7 @@ mod tests {
         bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "unchanged").expect("set extra");
         bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, "staged").expect("set validate");
 
-        RunUpdateGuard::rollback(true, None);
+        make_guard(true, None).rollback();
 
         assert_eq!(
             bootloader_env::get(OMNECT_EXTRA_BOOTARGS).expect("get extra"),
@@ -983,6 +994,24 @@ mod tests {
             bootloader_env::get(OMNECT_VALIDATE_EXTRA_BOOTARGS).expect("get validate"),
             "staged",
             "expected validate key to remain when bootloader was updated"
+        );
+    }
+
+    #[test]
+    fn rollback_removes_update_validation_config() {
+        let _lock = BOOTARGS_TEST_LOCK.lock().unwrap();
+        crate::bootloader_env::clear_mock();
+        let tmp = tempfile::tempdir().unwrap();
+
+        let config_path = tmp.path().join("update_validation_conf.json");
+        fs::write(&config_path, r#"{"local":true}"#).expect("write config");
+        crate::common::set_env_var("UPDATE_VALIDATION_CONFIG_PATH", &config_path);
+
+        make_guard(false, None).rollback();
+
+        assert!(
+            !config_path.exists(),
+            "expected update validation config to be removed by rollback"
         );
     }
 }

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -389,26 +389,22 @@ impl FirmwareUpdate {
         );
 
         let current_bootargs = bootloader_env::get("omnect_extra_bootargs")?;
-        let omnect_bootargs = fs::read_to_string(bootargs_omnect_file_path!())?;
-        let custom_bootargs = fs::read_to_string(bootargs_custom_file_path!())?;
+        let omnect_bootargs = fs::read_to_string(bootargs_omnect_file_path!()).unwrap_or_default();
+        let custom_bootargs = fs::read_to_string(bootargs_custom_file_path!()).unwrap_or_default();
         let new_bootargs = format!("{} {}", omnect_bootargs, custom_bootargs)
             .split_whitespace()
             .collect::<Vec<_>>()
             .join(" ");
 
         if current_bootargs != new_bootargs {
-            if bootloader_updated {
-                if new_bootargs.is_empty() {
-                    bootloader_env::unset("omnect_extra_bootargs")?;
-                } else {
-                    bootloader_env::set("omnect_extra_bootargs", &new_bootargs)?;
-                }
+            if bootloader_updated && new_bootargs.is_empty() {
+                bootloader_env::unset("omnect_extra_bootargs")?;
+            } else if bootloader_updated {
+                bootloader_env::set("omnect_extra_bootargs", &new_bootargs)?;
+            } else if new_bootargs.is_empty() {
+                bootloader_env::set("omnect_validate_extra_bootargs", "#noargs")?;
             } else {
-                if new_bootargs.is_empty() {
-                    bootloader_env::set("omnect_validate_extra_bootargs", "#noargs")?;
-                } else {
-                    bootloader_env::set("omnect_validate_extra_bootargs", &new_bootargs)?;
-                }
+                bootloader_env::set("omnect_validate_extra_bootargs", &new_bootargs)?;
             }
         }
 

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -111,10 +111,17 @@ impl RunUpdateGuard {
         self.succeeded = true;
     }
 
-    // rollback only logs errors during its processing and doesn't return on them
+    #[cfg(test)]
     fn rollback(&mut self) {
+        Self::do_rollback(self.bootloader_updated, self.bootargs_omnect_backup.take());
+    }
+
+    /// Rollback only logs errors during its processing and doesn't return on
+    /// them.  Extracted as a free-standing associated function so `Drop` can
+    /// move the fields into `spawn_blocking` without borrowing `self`.
+    fn do_rollback(bootloader_updated: bool, bootargs_omnect_backup: Option<PathBuf>) {
         // cannot rollback a stable,bootloader image once flashed
-        if self.bootloader_updated {
+        if bootloader_updated {
             warn!("bootloader was updated: rollback not possible");
             return;
         }
@@ -123,7 +130,7 @@ impl RunUpdateGuard {
             error!("failed to unset {OMNECT_VALIDATE_EXTRA_BOOTARGS}: {e:#}");
         }
 
-        if let Some(backup) = self.bootargs_omnect_backup.take() {
+        if let Some(backup) = bootargs_omnect_backup {
             let omnect_file = bootargs_omnect_file_path!();
             match fs::copy(&backup, &omnect_file) {
                 Err(e) => {
@@ -156,14 +163,20 @@ impl Drop for RunUpdateGuard {
     fn drop(&mut self) {
         if !(self.succeeded) {
             let wdt = self.wdt.take();
+            let bootloader_updated = self.bootloader_updated;
+            let bootargs_backup = self.bootargs_omnect_backup.take();
 
             debug!(
                 "run update failed: restore old wdt ({wdt:?}) and restart {IOT_HUB_DEVICE_UPDATE_SERVICE} and {IOT_HUB_DEVICE_UPDATE_SERVICE_TIMER}"
             );
 
-            self.rollback();
-
             tokio::spawn(async move {
+                tokio::task::spawn_blocking(move || {
+                    Self::do_rollback(bootloader_updated, bootargs_backup);
+                })
+                .await
+                .unwrap_or_else(|e| error!("rollback task panicked: {e:#}"));
+
                 if let Some(wdt) = wdt
                     && let Err(e) = WatchdogManager::interval(wdt).await
                 {
@@ -1043,6 +1056,9 @@ mod tests {
                 bootargs_omnect_backup: Some(backup_path.clone()),
             };
         } // _guard dropped here
+
+        // rollback runs inside tokio::spawn + spawn_blocking; wait for completion
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         assert_eq!(
             bootloader_env::get(OMNECT_EXTRA_BOOTARGS).expect("get extra"),

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -114,8 +114,8 @@ impl Drop for RunUpdateGuard {
                 }
 
                 // prevent booting from other partition if update failed, the bootloader maybe stuck otherwise when booting from a non-existing rootfs
-                if let Err(e) = bootloader_env::unset("omnect_validate_update_part") {
-                    error!("failed to unset omnect_validate_update_part: {e:#}")
+                if let Err(e) = bootloader_env::unset(OMNECT_VALIDATE_UPDATE_PART) {
+                    error!("failed to unset {OMNECT_VALIDATE_UPDATE_PART}: {e:#}")
                 }
 
                 if let Err(e) = systemd::unit::unit_action(
@@ -378,11 +378,11 @@ impl FirmwareUpdate {
         );
 
         if bootloader_updated {
-            bootloader_env::set("omnect_bootloader_updated", "1")?;
-            bootloader_env::set("omnect_os_bootpart", &target_partition.index().to_string())?;
+            bootloader_env::set(OMNECT_BOOTLOADER_UPDATED, "1")?;
+            bootloader_env::set(OMNECT_OS_BOOTPART, &target_partition.index().to_string())?;
         } else {
             bootloader_env::set(
-                "omnect_validate_update_part",
+                OMNECT_VALIDATE_UPDATE_PART,
                 &target_partition.index().to_string(),
             )?;
         }
@@ -415,7 +415,7 @@ impl FirmwareUpdate {
     }
 
     fn apply_bootargs(bootloader_updated: bool) -> Result<()> {
-        let current_bootargs = bootloader_env::get("omnect_extra_bootargs").unwrap_or_default();
+        let current_bootargs = bootloader_env::get(OMNECT_EXTRA_BOOTARGS).unwrap_or_default();
         let omnect_bootargs = fs::read_to_string(bootargs_omnect_file_path!())?; // has to exist
         let custom_bootargs = match fs::read_to_string(bootargs_custom_file_path!()) {
             Ok(s) => s,
@@ -429,13 +429,13 @@ impl FirmwareUpdate {
 
         if current_bootargs != new_bootargs {
             if bootloader_updated && new_bootargs.is_empty() {
-                bootloader_env::unset("omnect_extra_bootargs")?;
+                bootloader_env::unset(OMNECT_EXTRA_BOOTARGS)?;
             } else if bootloader_updated {
-                bootloader_env::set("omnect_extra_bootargs", &new_bootargs)?;
+                bootloader_env::set(OMNECT_EXTRA_BOOTARGS, &new_bootargs)?;
             } else if new_bootargs.is_empty() {
-                bootloader_env::set("omnect_validate_extra_bootargs", "#noargs")?;
+                bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, NOARGS_SENTINEL)?;
             } else {
-                bootloader_env::set("omnect_validate_extra_bootargs", &new_bootargs)?;
+                bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, &new_bootargs)?;
             }
         }
         Ok(())
@@ -671,16 +671,16 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         setup_bootargs_files(&tmp, "console=ttyS0,115200", "loglevel=7");
 
-        bootloader_env::set("omnect_extra_bootargs", "old_value").unwrap();
+        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").unwrap();
         FirmwareUpdate::apply_bootargs(false).unwrap();
 
         assert_eq!(
-            bootloader_env::get("omnect_validate_extra_bootargs").unwrap(),
+            bootloader_env::get(OMNECT_VALIDATE_EXTRA_BOOTARGS).unwrap(),
             "console=ttyS0,115200 loglevel=7"
         );
         // original key must be untouched
         assert_eq!(
-            bootloader_env::get("omnect_extra_bootargs").unwrap(),
+            bootloader_env::get(OMNECT_EXTRA_BOOTARGS).unwrap(),
             "old_value"
         );
     }
@@ -692,12 +692,12 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         setup_bootargs_files(&tmp, "   ", ""); // whitespace only → normalizes to empty
 
-        bootloader_env::set("omnect_extra_bootargs", "old_value").unwrap();
+        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").unwrap();
         FirmwareUpdate::apply_bootargs(false).unwrap();
 
         assert_eq!(
-            bootloader_env::get("omnect_validate_extra_bootargs").unwrap(),
-            "#noargs"
+            bootloader_env::get(OMNECT_VALIDATE_EXTRA_BOOTARGS).unwrap(),
+            NOARGS_SENTINEL
         );
     }
 
@@ -708,11 +708,11 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         setup_bootargs_files(&tmp, "quiet", "systemd.log_level=debug");
 
-        bootloader_env::set("omnect_extra_bootargs", "old_value").unwrap();
+        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").unwrap();
         FirmwareUpdate::apply_bootargs(true).unwrap();
 
         assert_eq!(
-            bootloader_env::get("omnect_extra_bootargs").unwrap(),
+            bootloader_env::get(OMNECT_EXTRA_BOOTARGS).unwrap(),
             "quiet systemd.log_level=debug"
         );
     }
@@ -724,11 +724,11 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         setup_bootargs_files(&tmp, "", "");
 
-        bootloader_env::set("omnect_extra_bootargs", "old_value").unwrap();
+        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").unwrap();
         FirmwareUpdate::apply_bootargs(true).unwrap();
 
         assert!(
-            bootloader_env::get("omnect_extra_bootargs")
+            bootloader_env::get(OMNECT_EXTRA_BOOTARGS)
                 .unwrap()
                 .is_empty(),
             "expected omnect_extra_bootargs to be unset"
@@ -742,11 +742,11 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         setup_bootargs_files(&tmp, "  arg1   arg2\n", "\n  arg3  ");
 
-        bootloader_env::set("omnect_extra_bootargs", "old_value").unwrap();
+        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").unwrap();
         FirmwareUpdate::apply_bootargs(true).unwrap();
 
         assert_eq!(
-            bootloader_env::get("omnect_extra_bootargs").unwrap(),
+            bootloader_env::get(OMNECT_EXTRA_BOOTARGS).unwrap(),
             "arg1 arg2 arg3"
         );
     }
@@ -758,15 +758,15 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         setup_bootargs_files(&tmp, "stable_arg", "");
 
-        bootloader_env::set("omnect_extra_bootargs", "stable_arg").unwrap();
+        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "stable_arg").unwrap();
         FirmwareUpdate::apply_bootargs(false).unwrap();
 
         assert_eq!(
-            bootloader_env::get("omnect_extra_bootargs").unwrap(),
+            bootloader_env::get(OMNECT_EXTRA_BOOTARGS).unwrap(),
             "stable_arg"
         );
         assert!(
-            bootloader_env::get("omnect_validate_extra_bootargs")
+            bootloader_env::get(OMNECT_VALIDATE_EXTRA_BOOTARGS)
                 .unwrap()
                 .is_empty(),
             "omnect_validate_extra_bootargs was unexpectedly set"
@@ -785,7 +785,7 @@ mod tests {
         fs::write(&custom_path, "loglevel=7").unwrap();
         crate::common::set_env_var("BOOTARGS_CUSTOM_FILE_PATH", &custom_path);
 
-        bootloader_env::set("omnect_extra_bootargs", "old_value").unwrap();
+        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").unwrap();
 
         assert!(FirmwareUpdate::apply_bootargs(false).is_err());
     }
@@ -802,11 +802,11 @@ mod tests {
         crate::common::set_env_var("BOOTARGS_OMNECT_FILE_PATH", &omnect_path);
         crate::common::set_env_var("BOOTARGS_CUSTOM_FILE_PATH", tmp.path().join("no_custom"));
 
-        bootloader_env::set("omnect_extra_bootargs", "old_value").unwrap();
+        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").unwrap();
         FirmwareUpdate::apply_bootargs(false).unwrap();
 
         assert_eq!(
-            bootloader_env::get("omnect_validate_extra_bootargs").unwrap(),
+            bootloader_env::get(OMNECT_VALIDATE_EXTRA_BOOTARGS).unwrap(),
             "console=ttyS0,115200"
         );
     }

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -901,9 +901,9 @@ mod tests {
         let omnect_path = tmp.path().join("bootargs_omnect");
         let custom_path = tmp.path().join("bootargs_custom");
         let backup_path = tmp.path().join("bootargs_omnect.backup");
-        fs::write(&omnect_path, omnect).expect("write omnect");
-        fs::write(&custom_path, custom).expect("write custom");
-        fs::write(&backup_path, omnect).expect("write backup");
+        fs::write(&omnect_path, omnect).unwrap();
+        fs::write(&custom_path, custom).unwrap();
+        fs::write(&backup_path, omnect).unwrap();
         crate::common::set_env_var("BOOTARGS_OMNECT_FILE_PATH", &omnect_path);
         crate::common::set_env_var("BOOTARGS_CUSTOM_FILE_PATH", &custom_path);
         crate::common::set_env_var("BOOTARGS_OMNECT_BACKUP_FILE_PATH", &backup_path);
@@ -918,24 +918,24 @@ mod tests {
         let (omnect_path, backup_path) = setup_rollback_files(&tmp, "original_arg", "custom_arg");
 
         // simulate kernelargs swupdate overwriting the omnect file
-        fs::write(&omnect_path, "corrupted").expect("overwrite omnect");
-        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").expect("set extra");
-        bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, "staged").expect("set validate");
+        fs::write(&omnect_path, "corrupted").unwrap();
+        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").unwrap();
+        bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, "staged").unwrap();
 
         make_guard(true, false, Some(backup_path.clone())).rollback();
 
         assert_eq!(
-            bootloader_env::get(OMNECT_EXTRA_BOOTARGS).expect("get extra"),
+            bootloader_env::get(OMNECT_EXTRA_BOOTARGS).unwrap(),
             "original_arg custom_arg"
         );
         assert!(
             bootloader_env::get(OMNECT_VALIDATE_EXTRA_BOOTARGS)
-                .expect("get validate")
+                .unwrap()
                 .is_empty(),
             "expected validate key to be unset"
         );
         assert_eq!(
-            fs::read_to_string(&omnect_path).expect("read omnect"),
+            fs::read_to_string(&omnect_path).unwrap(),
             "original_arg",
             "expected omnect file to be restored from backup"
         );
@@ -952,13 +952,13 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let (_omnect_path, backup_path) = setup_rollback_files(&tmp, "", "");
 
-        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").expect("set extra");
+        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").unwrap();
 
         make_guard(true, false, Some(backup_path)).rollback();
 
         assert!(
             bootloader_env::get(OMNECT_EXTRA_BOOTARGS)
-                .expect("get extra")
+                .unwrap()
                 .is_empty(),
             "expected omnect_extra_bootargs to be unset"
         );
@@ -969,19 +969,19 @@ mod tests {
         let _lock = BOOTARGS_TEST_LOCK.lock().unwrap();
         crate::bootloader_env::clear_mock();
 
-        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "unchanged").expect("set extra");
-        bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, "staged").expect("set validate");
+        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "unchanged").unwrap();
+        bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, "staged").unwrap();
 
         make_guard(true, false, None).rollback();
 
         assert_eq!(
-            bootloader_env::get(OMNECT_EXTRA_BOOTARGS).expect("get extra"),
+            bootloader_env::get(OMNECT_EXTRA_BOOTARGS).unwrap(),
             "unchanged",
             "expected omnect_extra_bootargs to remain unchanged"
         );
         assert!(
             bootloader_env::get(OMNECT_VALIDATE_EXTRA_BOOTARGS)
-                .expect("get validate")
+                .unwrap()
                 .is_empty(),
             "expected validate key to be unset"
         );
@@ -992,17 +992,17 @@ mod tests {
         let _lock = BOOTARGS_TEST_LOCK.lock().unwrap();
         crate::bootloader_env::clear_mock();
 
-        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "unchanged").expect("set extra");
-        bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, "staged").expect("set validate");
+        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "unchanged").unwrap();
+        bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, "staged").unwrap();
 
         make_guard(true, true, None).rollback();
 
         assert_eq!(
-            bootloader_env::get(OMNECT_EXTRA_BOOTARGS).expect("get extra"),
+            bootloader_env::get(OMNECT_EXTRA_BOOTARGS).unwrap(),
             "unchanged"
         );
         assert_eq!(
-            bootloader_env::get(OMNECT_VALIDATE_EXTRA_BOOTARGS).expect("get validate"),
+            bootloader_env::get(OMNECT_VALIDATE_EXTRA_BOOTARGS).unwrap(),
             "staged",
             "expected validate key to remain when bootloader was updated"
         );
@@ -1015,7 +1015,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
 
         let config_path = tmp.path().join("update_validation_conf.json");
-        fs::write(&config_path, r#"{"local":true}"#).expect("write config");
+        fs::write(&config_path, r#"{"local":true}"#).unwrap();
         crate::common::set_env_var("UPDATE_VALIDATION_CONFIG_PATH", &config_path);
 
         make_guard(true, false, None).rollback();
@@ -1034,13 +1034,13 @@ mod tests {
         let (omnect_path, backup_path) = setup_rollback_files(&tmp, "original_arg", "custom_arg");
 
         let config_path = tmp.path().join("update_validation_conf.json");
-        fs::write(&config_path, r#"{"local":true}"#).expect("write config");
+        fs::write(&config_path, r#"{"local":true}"#).unwrap();
         crate::common::set_env_var("UPDATE_VALIDATION_CONFIG_PATH", &config_path);
 
         // simulate kernelargs swupdate overwriting the omnect file
-        fs::write(&omnect_path, "corrupted").expect("overwrite omnect");
-        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").expect("set extra");
-        bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, "staged").expect("set validate");
+        fs::write(&omnect_path, "corrupted").unwrap();
+        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").unwrap();
+        bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, "staged").unwrap();
 
         // guard with succeeded=false — Drop must trigger rollback
         {
@@ -1051,17 +1051,17 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         assert_eq!(
-            bootloader_env::get(OMNECT_EXTRA_BOOTARGS).expect("get extra"),
+            bootloader_env::get(OMNECT_EXTRA_BOOTARGS).unwrap(),
             "original_arg custom_arg"
         );
         assert!(
             bootloader_env::get(OMNECT_VALIDATE_EXTRA_BOOTARGS)
-                .expect("get validate")
+                .unwrap()
                 .is_empty(),
             "expected validate key to be unset"
         );
         assert_eq!(
-            fs::read_to_string(&omnect_path).expect("read omnect"),
+            fs::read_to_string(&omnect_path).unwrap(),
             "original_arg",
             "expected omnect file to be restored from backup"
         );

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -111,11 +111,6 @@ impl RunUpdateGuard {
         self.succeeded = true;
     }
 
-    #[cfg(test)]
-    fn rollback(&mut self) {
-        Self::do_rollback(self.bootloader_updated, self.bootargs_omnect_backup.take());
-    }
-
     /// Rollback only logs errors during its processing and doesn't return on
     /// them.  Extracted as a free-standing associated function so `Drop` can
     /// move the fields into `spawn_blocking` without borrowing `self`.
@@ -893,6 +888,13 @@ mod tests {
         }
     }
 
+    fn rollback(guard: &mut RunUpdateGuard) {
+        RunUpdateGuard::do_rollback(
+            guard.bootloader_updated,
+            guard.bootargs_omnect_backup.take(),
+        );
+    }
+
     fn setup_rollback_files(
         tmp: &tempfile::TempDir,
         omnect: &str,
@@ -922,7 +924,7 @@ mod tests {
         bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").unwrap();
         bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, "staged").unwrap();
 
-        make_guard(true, false, Some(backup_path.clone())).rollback();
+        rollback(&mut make_guard(true, false, Some(backup_path.clone())));
 
         assert_eq!(
             bootloader_env::get(OMNECT_EXTRA_BOOTARGS).unwrap(),
@@ -954,7 +956,7 @@ mod tests {
 
         bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").unwrap();
 
-        make_guard(true, false, Some(backup_path)).rollback();
+        rollback(&mut make_guard(true, false, Some(backup_path)));
 
         assert!(
             bootloader_env::get(OMNECT_EXTRA_BOOTARGS)
@@ -972,7 +974,7 @@ mod tests {
         bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "unchanged").unwrap();
         bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, "staged").unwrap();
 
-        make_guard(true, false, None).rollback();
+        rollback(&mut make_guard(true, false, None));
 
         assert_eq!(
             bootloader_env::get(OMNECT_EXTRA_BOOTARGS).unwrap(),
@@ -995,7 +997,7 @@ mod tests {
         bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "unchanged").unwrap();
         bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, "staged").unwrap();
 
-        make_guard(true, true, None).rollback();
+        rollback(&mut make_guard(true, true, None));
 
         assert_eq!(
             bootloader_env::get(OMNECT_EXTRA_BOOTARGS).unwrap(),
@@ -1018,7 +1020,7 @@ mod tests {
         fs::write(&config_path, r#"{"local":true}"#).unwrap();
         crate::common::set_env_var("UPDATE_VALIDATION_CONFIG_PATH", &config_path);
 
-        make_guard(true, false, None).rollback();
+        rollback(&mut make_guard(true, false, None));
 
         assert!(
             !config_path.exists(),
@@ -1044,7 +1046,7 @@ mod tests {
 
         // Drop delegates to do_rollback — call rollback() directly to test
         // the same code path without relying on async timing.
-        make_guard(true, false, Some(backup_path.clone())).rollback();
+        rollback(&mut make_guard(true, false, Some(backup_path.clone())));
 
         assert_eq!(
             bootloader_env::get(OMNECT_EXTRA_BOOTARGS).unwrap(),

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -103,6 +103,7 @@ impl RunUpdateGuard {
         self.succeeded = true;
     }
 
+    // rollback only logs error's during it's processing and doesn't return on them
     fn rollback(&mut self) {
         // cannot rollback a stable,bootloader image once flashed
         if self.bootloader_updated {

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -765,24 +765,40 @@ mod tests {
     }
 
     #[test]
-    fn bootargs_missing_files_treated_as_empty() {
+    fn bootargs_missing_omnect_file_treated_as_error() {
+        let _lock = BOOTARGS_TEST_LOCK.lock().unwrap();
         crate::bootloader_env::clear_mock();
         let tmp = tempfile::tempdir().unwrap();
-        crate::common::set_env_var(
-            "BOOTARGS_OMNECT_FILE_PATH",
-            tmp.path().join("does_not_exist_1"),
-        );
-        crate::common::set_env_var(
-            "BOOTARGS_CUSTOM_FILE_PATH",
-            tmp.path().join("does_not_exist_2"),
-        );
+
+        // omnect file is missing → apply_bootargs must return Err
+        crate::common::set_env_var("BOOTARGS_OMNECT_FILE_PATH", tmp.path().join("no_omnect"));
+        let custom_path = tmp.path().join("bootargs_custom");
+        fs::write(&custom_path, "loglevel=7").unwrap();
+        crate::common::set_env_var("BOOTARGS_CUSTOM_FILE_PATH", &custom_path);
+
+        bootloader_env::set("omnect_extra_bootargs", "old_value").unwrap();
+
+        assert!(FirmwareUpdate::apply_bootargs(false).is_err());
+    }
+
+    #[test]
+    fn bootargs_missing_custom_file_treated_as_empty() {
+        let _lock = BOOTARGS_TEST_LOCK.lock().unwrap();
+        crate::bootloader_env::clear_mock();
+        let tmp = tempfile::tempdir().unwrap();
+
+        // omnect file exists with a value, custom file is missing → treated as ""
+        let omnect_path = tmp.path().join("bootargs_omnect");
+        fs::write(&omnect_path, "console=ttyS0,115200").unwrap();
+        crate::common::set_env_var("BOOTARGS_OMNECT_FILE_PATH", &omnect_path);
+        crate::common::set_env_var("BOOTARGS_CUSTOM_FILE_PATH", tmp.path().join("no_custom"));
 
         bootloader_env::set("omnect_extra_bootargs", "old_value").unwrap();
         FirmwareUpdate::apply_bootargs(false).unwrap();
 
         assert_eq!(
             bootloader_env::get("omnect_validate_extra_bootargs").unwrap(),
-            "#noargs"
+            "console=ttyS0,115200"
         );
     }
 }

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use anyhow::{Context, Result, bail, ensure};
 use base64::{Engine, prelude::BASE64_STANDARD};
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::{
@@ -64,6 +64,8 @@ impl Drop for LoadUpdateGuard {
 struct RunUpdateGuard {
     succeeded: bool,
     wdt: Option<Duration>,
+    bootloader_updated: bool,
+    bootargs_omnect_backup: Option<PathBuf>,
 }
 
 impl RunUpdateGuard {
@@ -89,11 +91,58 @@ impl RunUpdateGuard {
 
         debug!("stopped {IOT_HUB_DEVICE_UPDATE_SERVICE}");
 
-        Ok(RunUpdateGuard { succeeded, wdt })
+        Ok(RunUpdateGuard {
+            succeeded,
+            wdt,
+            bootloader_updated: false,
+            bootargs_omnect_backup: None,
+        })
     }
 
     fn finalize(&mut self) {
         self.succeeded = true;
+    }
+
+    fn rollback(bootloader_updated: bool, bootargs_omnect_backup: Option<PathBuf>) {
+        // cannot rollback a stable,bootloader image once flashed
+        if bootloader_updated {
+            warn!("bootloader was updated: rollback not possible");
+            return;
+        }
+
+        if let Err(e) = bootloader_env::unset(OMNECT_VALIDATE_EXTRA_BOOTARGS) {
+            error!("failed to unset {OMNECT_VALIDATE_EXTRA_BOOTARGS}: {e:#}");
+        }
+
+        if let Some(backup) = bootargs_omnect_backup {
+            let omnect_file = bootargs_omnect_file_path!();
+            match fs::copy(&backup, &omnect_file) {
+                Err(e) => {
+                    error!("failed to restore omnect bootargs file from backup: {e:#}");
+                }
+                Ok(_) => {
+                    let omnect_args = fs::read_to_string(&omnect_file).unwrap_or_default();
+                    let custom_args =
+                        fs::read_to_string(bootargs_custom_file_path!()).unwrap_or_default();
+                    let new_bootargs = format!("{omnect_args} {custom_args}")
+                        .split_whitespace()
+                        .collect::<Vec<_>>()
+                        .join(" ");
+
+                    let result = if new_bootargs.is_empty() {
+                        bootloader_env::unset(OMNECT_EXTRA_BOOTARGS)
+                    } else {
+                        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, &new_bootargs)
+                    };
+                    if let Err(e) = result {
+                        error!("failed to restore {OMNECT_EXTRA_BOOTARGS}: {e:#}");
+                    }
+                }
+            }
+            let _ = fs::remove_file(&backup);
+        }
+
+        let _ = fs::remove_file(update_validation_config_path!());
     }
 }
 
@@ -101,6 +150,8 @@ impl Drop for RunUpdateGuard {
     fn drop(&mut self) {
         if !(self.succeeded) {
             let wdt = self.wdt.take();
+            let bootloader_updated = self.bootloader_updated;
+            let bootargs_omnect_backup = self.bootargs_omnect_backup.take();
 
             debug!(
                 "run update failed: restore old wdt ({wdt:?}) and restart {IOT_HUB_DEVICE_UPDATE_SERVICE} and {IOT_HUB_DEVICE_UPDATE_SERVICE_TIMER}"
@@ -113,10 +164,7 @@ impl Drop for RunUpdateGuard {
                     error!("failed to restore wdt interval: {e:#}")
                 }
 
-                // prevent booting from other partition if update failed, the bootloader maybe stuck otherwise when booting from a non-existing rootfs
-                if let Err(e) = bootloader_env::unset(OMNECT_VALIDATE_UPDATE_PART) {
-                    error!("failed to unset {OMNECT_VALIDATE_UPDATE_PART}: {e:#}")
-                }
+                Self::rollback(bootloader_updated, bootargs_omnect_backup);
 
                 if let Err(e) = systemd::unit::unit_action(
                     IOT_HUB_DEVICE_UPDATE_SERVICE,
@@ -377,6 +425,18 @@ impl FirmwareUpdate {
             log_file_path!()
         );
 
+        guard.bootloader_updated = bootloader_updated;
+
+        let omnect_file = bootargs_omnect_file_path!();
+        let backup_file = PathBuf::from(bootargs_omnect_backup_file_path!());
+        if Path::new(&omnect_file).exists() {
+            fs::copy(&omnect_file, &backup_file)
+                .context("failed to back up omnect bootargs file")?;
+            guard.bootargs_omnect_backup = Some(backup_file);
+        } else {
+            error!("omnect bootargs file not found: {omnect_file}, skipping backup");
+        }
+
         #[cfg(not(feature = "mock"))]
         Self::swupdate(swu_file_path, target_partition.kernelargs_update_params()).context(
             format!(
@@ -386,6 +446,14 @@ impl FirmwareUpdate {
         )?;
 
         Self::apply_bootargs(bootloader_updated)?;
+
+        to_json_file(
+            &UpdateValidationConfig {
+                local: !validate_iothub_connection,
+            },
+            update_validation_config_path!(),
+            true,
+        )?;
 
         if bootloader_updated {
             bootloader_env::set(OMNECT_BOOTLOADER_UPDATED, "1")?;
@@ -397,19 +465,11 @@ impl FirmwareUpdate {
             )?;
         }
 
-        to_json_file(
-            &UpdateValidationConfig {
-                local: !validate_iothub_connection,
-            },
-            update_validation_config_path!(),
-            true,
-        )?;
+        guard.finalize();
 
         systemd::reboot("swupdate", "local update").await?;
 
         info!("update succeeded");
-
-        guard.finalize();
 
         Ok(None)
     }
@@ -808,6 +868,121 @@ mod tests {
         assert_eq!(
             bootloader_env::get(OMNECT_VALIDATE_EXTRA_BOOTARGS).unwrap(),
             "console=ttyS0,115200"
+        );
+    }
+
+    fn setup_rollback_files(
+        tmp: &tempfile::TempDir,
+        omnect: &str,
+        custom: &str,
+    ) -> (PathBuf, PathBuf) {
+        let omnect_path = tmp.path().join("bootargs_omnect");
+        let custom_path = tmp.path().join("bootargs_custom");
+        let backup_path = tmp.path().join("bootargs_omnect.backup");
+        fs::write(&omnect_path, omnect).expect("write omnect");
+        fs::write(&custom_path, custom).expect("write custom");
+        fs::write(&backup_path, omnect).expect("write backup");
+        crate::common::set_env_var("BOOTARGS_OMNECT_FILE_PATH", &omnect_path);
+        crate::common::set_env_var("BOOTARGS_CUSTOM_FILE_PATH", &custom_path);
+        crate::common::set_env_var("BOOTARGS_OMNECT_BACKUP_FILE_PATH", &backup_path);
+        (omnect_path, backup_path)
+    }
+
+    #[test]
+    fn rollback_restores_bootargs_from_backup() {
+        let _lock = BOOTARGS_TEST_LOCK.lock().unwrap();
+        crate::bootloader_env::clear_mock();
+        let tmp = tempfile::tempdir().unwrap();
+        let (omnect_path, backup_path) = setup_rollback_files(&tmp, "original_arg", "custom_arg");
+
+        // simulate kernelargs swupdate overwriting the omnect file
+        fs::write(&omnect_path, "corrupted").expect("overwrite omnect");
+        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").expect("set extra");
+        bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, "staged").expect("set validate");
+
+        RunUpdateGuard::rollback(false, Some(backup_path.clone()));
+
+        assert_eq!(
+            bootloader_env::get(OMNECT_EXTRA_BOOTARGS).expect("get extra"),
+            "original_arg custom_arg"
+        );
+        assert!(
+            bootloader_env::get(OMNECT_VALIDATE_EXTRA_BOOTARGS)
+                .expect("get validate")
+                .is_empty(),
+            "expected validate key to be unset"
+        );
+        assert_eq!(
+            fs::read_to_string(&omnect_path).expect("read omnect"),
+            "original_arg",
+            "expected omnect file to be restored from backup"
+        );
+        assert!(
+            !backup_path.exists(),
+            "expected backup file to be cleaned up"
+        );
+    }
+
+    #[test]
+    fn rollback_empty_bootargs_unsets_env_var() {
+        let _lock = BOOTARGS_TEST_LOCK.lock().unwrap();
+        crate::bootloader_env::clear_mock();
+        let tmp = tempfile::tempdir().unwrap();
+        let (_omnect_path, backup_path) = setup_rollback_files(&tmp, "", "");
+
+        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").expect("set extra");
+
+        RunUpdateGuard::rollback(false, Some(backup_path));
+
+        assert!(
+            bootloader_env::get(OMNECT_EXTRA_BOOTARGS)
+                .expect("get extra")
+                .is_empty(),
+            "expected omnect_extra_bootargs to be unset"
+        );
+    }
+
+    #[test]
+    fn rollback_without_backup_only_unsets_validate_key() {
+        let _lock = BOOTARGS_TEST_LOCK.lock().unwrap();
+        crate::bootloader_env::clear_mock();
+
+        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "unchanged").expect("set extra");
+        bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, "staged").expect("set validate");
+
+        RunUpdateGuard::rollback(false, None);
+
+        assert_eq!(
+            bootloader_env::get(OMNECT_EXTRA_BOOTARGS).expect("get extra"),
+            "unchanged",
+            "expected omnect_extra_bootargs to remain unchanged"
+        );
+        assert!(
+            bootloader_env::get(OMNECT_VALIDATE_EXTRA_BOOTARGS)
+                .expect("get validate")
+                .is_empty(),
+            "expected validate key to be unset"
+        );
+    }
+
+    #[test]
+    fn rollback_bootloader_updated_does_nothing() {
+        let _lock = BOOTARGS_TEST_LOCK.lock().unwrap();
+        crate::bootloader_env::clear_mock();
+
+        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "unchanged").expect("set extra");
+        bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, "staged").expect("set validate");
+
+        RunUpdateGuard::rollback(true, None);
+
+        assert_eq!(
+            bootloader_env::get(OMNECT_EXTRA_BOOTARGS).expect("get extra"),
+            "unchanged"
+        );
+        assert_eq!(
+            bootloader_env::get(OMNECT_VALIDATE_EXTRA_BOOTARGS).expect("get validate"),
+            "staged",
+            "expected validate key to remain when bootloader was updated"
         );
     }
 }

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -382,6 +382,36 @@ impl FirmwareUpdate {
             )?;
         }
 
+        ensure!(
+            Self::swupdate(swu_file_path, target_partition.kernelargs_update_params()).is_ok(),
+            "failed to update kernelargs. (swupdate logs at {})",
+            log_file_path!()
+        );
+
+        let current_bootargs = bootloader_env::get("omnect_extra_bootargs")?;
+        let omnect_bootargs = fs::read_to_string(bootargs_omnect_file_path!())?;
+        let custom_bootargs = fs::read_to_string(bootargs_custom_file_path!())?;
+        let new_bootargs = format!("{} {}", omnect_bootargs, custom_bootargs)
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        if current_bootargs != new_bootargs {
+            if bootloader_updated {
+                if new_bootargs.is_empty() {
+                    bootloader_env::unset("omnect_extra_bootargs")?;
+                } else {
+                    bootloader_env::set("omnect_extra_bootargs", &new_bootargs)?;
+                }
+            } else {
+                if new_bootargs.is_empty() {
+                    bootloader_env::set("omnect_validate_extra_bootargs", "#noargs")?;
+                } else {
+                    bootloader_env::set("omnect_validate_extra_bootargs", &new_bootargs)?;
+                }
+            }
+        }
+
         to_json_file(
             &UpdateValidationConfig {
                 local: !validate_iothub_connection,

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -393,25 +393,7 @@ impl FirmwareUpdate {
             log_file_path!()
         );
 
-        let current_bootargs = bootloader_env::get("omnect_extra_bootargs")?;
-        let omnect_bootargs = fs::read_to_string(bootargs_omnect_file_path!())?;
-        let custom_bootargs = fs::read_to_string(bootargs_custom_file_path!()).unwrap_or_default(); //custom existence is optional and not part of the wic image
-        let new_bootargs = format!("{} {}", omnect_bootargs, custom_bootargs)
-            .split_whitespace()
-            .collect::<Vec<_>>()
-            .join(" ");
-
-        if current_bootargs != new_bootargs {
-            if bootloader_updated && new_bootargs.is_empty() {
-                bootloader_env::unset("omnect_extra_bootargs")?;
-            } else if bootloader_updated {
-                bootloader_env::set("omnect_extra_bootargs", &new_bootargs)?;
-            } else if new_bootargs.is_empty() {
-                bootloader_env::set("omnect_validate_extra_bootargs", "#noargs")?;
-            } else {
-                bootloader_env::set("omnect_validate_extra_bootargs", &new_bootargs)?;
-            }
-        }
+        Self::apply_bootargs(bootloader_updated)?;
 
         to_json_file(
             &UpdateValidationConfig {
@@ -428,6 +410,29 @@ impl FirmwareUpdate {
         guard.finalize();
 
         Ok(None)
+    }
+
+    fn apply_bootargs(bootloader_updated: bool) -> Result<()> {
+        let current_bootargs = bootloader_env::get("omnect_extra_bootargs")?;
+        let omnect_bootargs = fs::read_to_string(bootargs_omnect_file_path!()).unwrap_or_default();
+        let custom_bootargs = fs::read_to_string(bootargs_custom_file_path!()).unwrap_or_default();
+        let new_bootargs = format!("{} {}", omnect_bootargs, custom_bootargs)
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        if current_bootargs != new_bootargs {
+            if bootloader_updated && new_bootargs.is_empty() {
+                bootloader_env::unset("omnect_extra_bootargs")?;
+            } else if bootloader_updated {
+                bootloader_env::set("omnect_extra_bootargs", &new_bootargs)?;
+            } else if new_bootargs.is_empty() {
+                bootloader_env::set("omnect_validate_extra_bootargs", "#noargs")?;
+            } else {
+                bootloader_env::set("omnect_validate_extra_bootargs", &new_bootargs)?;
+            }
+        }
+        Ok(())
     }
 
     fn swupdate<P>(swu_file_path: P, selection: &str) -> Result<()>
@@ -483,7 +488,22 @@ impl FirmwareUpdate {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
     use tempfile;
+
+    // Serializes all bootargs tests because both set_env_var (for file paths)
+    // and the bootloader_env mock store are global state.
+    static BOOTARGS_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    // helper
+    fn setup_bootargs_files(tmp: &tempfile::TempDir, omnect: &str, custom: &str) {
+        let omnect_path = tmp.path().join("bootargs_omnect");
+        let custom_path = tmp.path().join("bootargs_custom");
+        fs::write(&omnect_path, omnect).unwrap();
+        fs::write(&custom_path, custom).unwrap();
+        crate::common::set_env_var("BOOTARGS_OMNECT_FILE_PATH", &omnect_path);
+        crate::common::set_env_var("BOOTARGS_CUSTOM_FILE_PATH", &custom_path);
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn load_ok() {
@@ -636,5 +656,133 @@ mod tests {
             e.to_string()
                 .starts_with("failed to verify compatibility: compatibilityid")
         }));
+    }
+
+    #[test]
+    fn bootargs_no_update_new_args_sets_validate_key() {
+        let _lock = BOOTARGS_TEST_LOCK.lock().unwrap();
+        crate::bootloader_env::clear_mock();
+        let tmp = tempfile::tempdir().unwrap();
+        setup_bootargs_files(&tmp, "console=ttyS0,115200", "loglevel=7");
+
+        bootloader_env::set("omnect_extra_bootargs", "old_value").unwrap();
+        FirmwareUpdate::apply_bootargs(false).unwrap();
+
+        assert_eq!(
+            bootloader_env::get("omnect_validate_extra_bootargs").unwrap(),
+            "console=ttyS0,115200 loglevel=7"
+        );
+        // original key must be untouched
+        assert_eq!(
+            bootloader_env::get("omnect_extra_bootargs").unwrap(),
+            "old_value"
+        );
+    }
+
+    #[test]
+    fn bootargs_no_update_empty_args_sets_noargs_sentinel() {
+        let _lock = BOOTARGS_TEST_LOCK.lock().unwrap();
+        crate::bootloader_env::clear_mock();
+        let tmp = tempfile::tempdir().unwrap();
+        setup_bootargs_files(&tmp, "   ", ""); // whitespace only → normalizes to empty
+
+        bootloader_env::set("omnect_extra_bootargs", "old_value").unwrap();
+        FirmwareUpdate::apply_bootargs(false).unwrap();
+
+        assert_eq!(
+            bootloader_env::get("omnect_validate_extra_bootargs").unwrap(),
+            "#noargs"
+        );
+    }
+
+    #[test]
+    fn bootargs_bootloader_updated_new_args_sets_extra_bootargs() {
+        let _lock = BOOTARGS_TEST_LOCK.lock().unwrap();
+        crate::bootloader_env::clear_mock();
+        let tmp = tempfile::tempdir().unwrap();
+        setup_bootargs_files(&tmp, "quiet", "systemd.log_level=debug");
+
+        bootloader_env::set("omnect_extra_bootargs", "old_value").unwrap();
+        FirmwareUpdate::apply_bootargs(true).unwrap();
+
+        assert_eq!(
+            bootloader_env::get("omnect_extra_bootargs").unwrap(),
+            "quiet systemd.log_level=debug"
+        );
+    }
+
+    #[test]
+    fn bootargs_bootloader_updated_empty_args_unsets_extra_bootargs() {
+        crate::bootloader_env::clear_mock();
+        let tmp = tempfile::tempdir().unwrap();
+        setup_bootargs_files(&tmp, "", "");
+
+        bootloader_env::set("omnect_extra_bootargs", "old_value").unwrap();
+        FirmwareUpdate::apply_bootargs(true).unwrap();
+
+        assert!(
+            bootloader_env::get("omnect_extra_bootargs")
+                .unwrap()
+                .is_empty(),
+            "expected omnect_extra_bootargs to be unset"
+        );
+    }
+
+    #[test]
+    fn bootargs_whitespace_is_normalized() {
+        crate::bootloader_env::clear_mock();
+        let tmp = tempfile::tempdir().unwrap();
+        setup_bootargs_files(&tmp, "  arg1   arg2\n", "\n  arg3  ");
+
+        bootloader_env::set("omnect_extra_bootargs", "old_value").unwrap();
+        FirmwareUpdate::apply_bootargs(true).unwrap();
+
+        assert_eq!(
+            bootloader_env::get("omnect_extra_bootargs").unwrap(),
+            "arg1 arg2 arg3"
+        );
+    }
+
+    #[test]
+    fn bootargs_unchanged_does_not_write_env() {
+        crate::bootloader_env::clear_mock();
+        let tmp = tempfile::tempdir().unwrap();
+        setup_bootargs_files(&tmp, "stable_arg", "");
+
+        bootloader_env::set("omnect_extra_bootargs", "stable_arg").unwrap();
+        FirmwareUpdate::apply_bootargs(false).unwrap();
+
+        assert_eq!(
+            bootloader_env::get("omnect_extra_bootargs").unwrap(),
+            "stable_arg"
+        );
+        assert!(
+            bootloader_env::get("omnect_validate_extra_bootargs")
+                .unwrap()
+                .is_empty(),
+            "omnect_validate_extra_bootargs was unexpectedly set"
+        );
+    }
+
+    #[test]
+    fn bootargs_missing_files_treated_as_empty() {
+        crate::bootloader_env::clear_mock();
+        let tmp = tempfile::tempdir().unwrap();
+        crate::common::set_env_var(
+            "BOOTARGS_OMNECT_FILE_PATH",
+            tmp.path().join("does_not_exist_1"),
+        );
+        crate::common::set_env_var(
+            "BOOTARGS_CUSTOM_FILE_PATH",
+            tmp.path().join("does_not_exist_2"),
+        );
+
+        bootloader_env::set("omnect_extra_bootargs", "old_value").unwrap();
+        FirmwareUpdate::apply_bootargs(false).unwrap();
+
+        assert_eq!(
+            bootloader_env::get("omnect_validate_extra_bootargs").unwrap(),
+            "#noargs"
+        );
     }
 }

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -413,7 +413,8 @@ impl FirmwareUpdate {
     }
 
     fn apply_bootargs(bootloader_updated: bool) -> Result<()> {
-        let current_bootargs = bootloader_env::get("omnect_extra_bootargs")?;
+        let current_bootargs =
+            bootloader_env::get("omnect_extra_bootargs").unwrap_or_default();
         let omnect_bootargs = fs::read_to_string(bootargs_omnect_file_path!())?; // has to exist
         let custom_bootargs = fs::read_to_string(bootargs_custom_file_path!()).unwrap_or_default(); // optional
         let new_bootargs = format!("{} {}", omnect_bootargs, custom_bootargs)

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -884,11 +884,12 @@ mod tests {
     }
 
     fn make_guard(
+        succeeded: bool,
         bootloader_updated: bool,
         bootargs_omnect_backup: Option<PathBuf>,
     ) -> RunUpdateGuard {
         RunUpdateGuard {
-            succeeded: true, // prevent Drop from running async cleanup
+            succeeded,
             wdt: None,
             bootloader_updated,
             bootargs_omnect_backup,
@@ -924,7 +925,7 @@ mod tests {
         bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").expect("set extra");
         bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, "staged").expect("set validate");
 
-        make_guard(false, Some(backup_path.clone())).rollback();
+        make_guard(true, false, Some(backup_path.clone())).rollback();
 
         assert_eq!(
             bootloader_env::get(OMNECT_EXTRA_BOOTARGS).expect("get extra"),
@@ -956,7 +957,7 @@ mod tests {
 
         bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").expect("set extra");
 
-        make_guard(false, Some(backup_path)).rollback();
+        make_guard(true, false, Some(backup_path)).rollback();
 
         assert!(
             bootloader_env::get(OMNECT_EXTRA_BOOTARGS)
@@ -974,7 +975,7 @@ mod tests {
         bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "unchanged").expect("set extra");
         bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, "staged").expect("set validate");
 
-        make_guard(false, None).rollback();
+        make_guard(true, false, None).rollback();
 
         assert_eq!(
             bootloader_env::get(OMNECT_EXTRA_BOOTARGS).expect("get extra"),
@@ -997,7 +998,7 @@ mod tests {
         bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "unchanged").expect("set extra");
         bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, "staged").expect("set validate");
 
-        make_guard(true, None).rollback();
+        make_guard(true, true, None).rollback();
 
         assert_eq!(
             bootloader_env::get(OMNECT_EXTRA_BOOTARGS).expect("get extra"),
@@ -1020,7 +1021,7 @@ mod tests {
         fs::write(&config_path, r#"{"local":true}"#).expect("write config");
         crate::common::set_env_var("UPDATE_VALIDATION_CONFIG_PATH", &config_path);
 
-        make_guard(false, None).rollback();
+        make_guard(true, false, None).rollback();
 
         assert!(
             !config_path.exists(),
@@ -1046,12 +1047,7 @@ mod tests {
 
         // guard with succeeded=false — Drop must trigger rollback
         {
-            let _guard = RunUpdateGuard {
-                succeeded: false,
-                wdt: None,
-                bootloader_updated: false,
-                bootargs_omnect_backup: Some(backup_path.clone()),
-            };
+            let _guard = make_guard(false, false, Some(backup_path.clone()));
         } // _guard dropped here
 
         // rollback runs inside tokio::spawn + spawn_blocking; wait for completion

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -566,12 +566,9 @@ impl FirmwareUpdate {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
     use tempfile;
 
-    // Serializes all bootargs tests because both set_env_var (for file paths)
-    // and the bootloader_env mock store are global state.
-    static BOOTARGS_TEST_LOCK: Mutex<()> = Mutex::new(());
+    use crate::bootloader_env::TEST_LOCK as BOOTARGS_TEST_LOCK;
 
     // helper
     fn setup_bootargs_files(tmp: &tempfile::TempDir, omnect: &str, custom: &str) {

--- a/src/twin/firmware_update/mod.rs
+++ b/src/twin/firmware_update/mod.rs
@@ -414,8 +414,8 @@ impl FirmwareUpdate {
 
     fn apply_bootargs(bootloader_updated: bool) -> Result<()> {
         let current_bootargs = bootloader_env::get("omnect_extra_bootargs")?;
-        let omnect_bootargs = fs::read_to_string(bootargs_omnect_file_path!()).unwrap_or_default();
-        let custom_bootargs = fs::read_to_string(bootargs_custom_file_path!()).unwrap_or_default();
+        let omnect_bootargs = fs::read_to_string(bootargs_omnect_file_path!())?; // has to exist
+        let custom_bootargs = fs::read_to_string(bootargs_custom_file_path!()).unwrap_or_default(); // optional
         let new_bootargs = format!("{} {}", omnect_bootargs, custom_bootargs)
             .split_whitespace()
             .collect::<Vec<_>>()

--- a/src/twin/firmware_update/update_validation.rs
+++ b/src/twin/firmware_update/update_validation.rs
@@ -192,7 +192,6 @@ impl UpdateValidation {
             bootloader_env::unset("extra_bootargs")?;
         }
 
-        bootloader_env::set("extra_bootargs", &omnect_validate_extra_bootargs)?;
         bootloader_env::unset("omnect_validate_update")?;
         bootloader_env::unset("omnect_validate_update_part")?;
         bootloader_env::unset("omnect_validate_extra_bootargs")?;

--- a/src/twin/firmware_update/update_validation.rs
+++ b/src/twin/firmware_update/update_validation.rs
@@ -179,26 +179,26 @@ impl UpdateValidation {
     async fn finalize(status: Arc<RwLock<UpdateValidationStatus>>) -> Result<()> {
         info!("finalize update");
         let omnect_validate_update_part =
-            RootPartition::from_index_string(bootloader_env::get("omnect_validate_update_part")?)?;
+            RootPartition::from_index_string(bootloader_env::get(OMNECT_VALIDATE_UPDATE_PART)?)?;
         let omnect_validate_extra_bootargs =
-            bootloader_env::get("omnect_validate_extra_bootargs").unwrap_or_default();
+            bootloader_env::get(OMNECT_VALIDATE_EXTRA_BOOTARGS).unwrap_or_default();
 
         bootloader_env::set(
-            "omnect_os_bootpart",
+            OMNECT_OS_BOOTPART,
             &omnect_validate_update_part.index().to_string(),
         )?;
 
-        if omnect_validate_extra_bootargs == "#noargs" {
-            bootloader_env::unset("omnect_extra_bootargs")?;
-            bootloader_env::unset("omnect_validate_extra_bootargs")?;
+        if omnect_validate_extra_bootargs == NOARGS_SENTINEL {
+            bootloader_env::unset(OMNECT_EXTRA_BOOTARGS)?;
+            bootloader_env::unset(OMNECT_VALIDATE_EXTRA_BOOTARGS)?;
         } else if !omnect_validate_extra_bootargs.is_empty() {
-            bootloader_env::set("omnect_extra_bootargs", &omnect_validate_extra_bootargs)?;
-            bootloader_env::unset("omnect_validate_extra_bootargs")?;
+            bootloader_env::set(OMNECT_EXTRA_BOOTARGS, &omnect_validate_extra_bootargs)?;
+            bootloader_env::unset(OMNECT_VALIDATE_EXTRA_BOOTARGS)?;
         }
         // else empty omnect_validate_extra bootargs -> explicitly no set of omnect_extra_bootargs
 
         bootloader_env::unset("omnect_validate_update")?;
-        bootloader_env::unset("omnect_validate_update_part")?;
+        bootloader_env::unset(OMNECT_VALIDATE_UPDATE_PART)?;
 
         fs::remove_file(UPDATE_VALIDATION_COMPLETE_BARRIER_FILE).context(format!(
             "update validation: remove {UPDATE_VALIDATION_COMPLETE_BARRIER_FILE}"

--- a/src/twin/firmware_update/update_validation.rs
+++ b/src/twin/firmware_update/update_validation.rs
@@ -180,13 +180,22 @@ impl UpdateValidation {
         info!("finalize update");
         let omnect_validate_update_part =
             RootPartition::from_index_string(bootloader_env::get("omnect_validate_update_part")?)?;
+        let omnect_validate_extra_bootargs = bootloader_env::get("omnect_validate_extra_bootargs")?;
 
         bootloader_env::set(
             "omnect_os_bootpart",
             &omnect_validate_update_part.index().to_string(),
         )?;
+        if !omnect_validate_extra_bootargs.is_empty() {
+            bootloader_env::set("extra_bootargs", &omnect_validate_extra_bootargs)?;
+        } else {
+            bootloader_env::unset("extra_bootargs")?;
+        }
+
+        bootloader_env::set("extra_bootargs", &omnect_validate_extra_bootargs)?;
         bootloader_env::unset("omnect_validate_update")?;
         bootloader_env::unset("omnect_validate_update_part")?;
+        bootloader_env::unset("omnect_validate_extra_bootargs")?;
 
         fs::remove_file(UPDATE_VALIDATION_COMPLETE_BARRIER_FILE).context(format!(
             "update validation: remove {UPDATE_VALIDATION_COMPLETE_BARRIER_FILE}"

--- a/src/twin/firmware_update/update_validation.rs
+++ b/src/twin/firmware_update/update_validation.rs
@@ -180,7 +180,8 @@ impl UpdateValidation {
         info!("finalize update");
         let omnect_validate_update_part =
             RootPartition::from_index_string(bootloader_env::get("omnect_validate_update_part")?)?;
-        let omnect_validate_extra_bootargs = bootloader_env::get("omnect_validate_extra_bootargs")?;
+        let omnect_validate_extra_bootargs =
+            bootloader_env::get("omnect_validate_extra_bootargs").unwrap_or_default();
 
         bootloader_env::set(
             "omnect_os_bootpart",

--- a/src/twin/firmware_update/update_validation.rs
+++ b/src/twin/firmware_update/update_validation.rs
@@ -187,9 +187,9 @@ impl UpdateValidation {
             &omnect_validate_update_part.index().to_string(),
         )?;
         if !omnect_validate_extra_bootargs.is_empty() {
-            bootloader_env::set("extra_bootargs", &omnect_validate_extra_bootargs)?;
+            bootloader_env::set("omnect_extra_bootargs", &omnect_validate_extra_bootargs)?;
         } else {
-            bootloader_env::unset("extra_bootargs")?;
+            bootloader_env::unset("omnect_extra_bootargs,")?;
         }
 
         bootloader_env::unset("omnect_validate_update")?;

--- a/src/twin/firmware_update/update_validation.rs
+++ b/src/twin/firmware_update/update_validation.rs
@@ -180,22 +180,12 @@ impl UpdateValidation {
         info!("finalize update");
         let omnect_validate_update_part =
             RootPartition::from_index_string(bootloader_env::get(OMNECT_VALIDATE_UPDATE_PART)?)?;
-        let omnect_validate_extra_bootargs =
-            bootloader_env::get(OMNECT_VALIDATE_EXTRA_BOOTARGS).unwrap_or_default();
-
         bootloader_env::set(
             OMNECT_OS_BOOTPART,
             &omnect_validate_update_part.index().to_string(),
         )?;
 
-        if omnect_validate_extra_bootargs == NOARGS_SENTINEL {
-            bootloader_env::unset(OMNECT_EXTRA_BOOTARGS)?;
-            bootloader_env::unset(OMNECT_VALIDATE_EXTRA_BOOTARGS)?;
-        } else if !omnect_validate_extra_bootargs.is_empty() {
-            bootloader_env::set(OMNECT_EXTRA_BOOTARGS, &omnect_validate_extra_bootargs)?;
-            bootloader_env::unset(OMNECT_VALIDATE_EXTRA_BOOTARGS)?;
-        }
-        // else empty omnect_validate_extra bootargs -> explicitly no set of omnect_extra_bootargs
+        Self::finalize_bootargs()?;
 
         bootloader_env::unset(OMNECT_VALIDATE_UPDATE)?;
         bootloader_env::unset(OMNECT_VALIDATE_UPDATE_PART)?;
@@ -272,6 +262,22 @@ impl UpdateValidation {
         Ok(())
     }
 
+    fn finalize_bootargs() -> Result<()> {
+        let omnect_validate_extra_bootargs =
+            bootloader_env::get(OMNECT_VALIDATE_EXTRA_BOOTARGS).unwrap_or_default();
+
+        if omnect_validate_extra_bootargs == NOARGS_SENTINEL {
+            bootloader_env::unset(OMNECT_EXTRA_BOOTARGS)?;
+            bootloader_env::unset(OMNECT_VALIDATE_EXTRA_BOOTARGS)?;
+        } else if !omnect_validate_extra_bootargs.is_empty() {
+            bootloader_env::set(OMNECT_EXTRA_BOOTARGS, &omnect_validate_extra_bootargs)?;
+            bootloader_env::unset(OMNECT_VALIDATE_EXTRA_BOOTARGS)?;
+        }
+        // else empty omnect_validate_extra_bootargs -> no change to omnect_extra_bootargs
+
+        Ok(())
+    }
+
     fn timeout() -> Duration {
         let mut timeout = Duration::from_secs(UPDATE_VALIDATION_TIMEOUT_IN_SECS_DEFAULT);
         if let Ok(secs) = env::var("UPDATE_VALIDATION_TIMEOUT_IN_SECS") {
@@ -286,5 +292,71 @@ impl UpdateValidation {
             };
         }
         timeout
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finalize_bootargs_noargs_sentinel_unsets_both_keys() {
+        crate::bootloader_env::clear_mock();
+        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").expect("set extra");
+        bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, NOARGS_SENTINEL).expect("set validate");
+
+        UpdateValidation::finalize_bootargs().expect("finalize_bootargs");
+
+        assert!(
+            bootloader_env::get(OMNECT_EXTRA_BOOTARGS)
+                .expect("get extra")
+                .is_empty(),
+            "expected omnect_extra_bootargs to be unset"
+        );
+        assert!(
+            bootloader_env::get(OMNECT_VALIDATE_EXTRA_BOOTARGS)
+                .expect("get validate")
+                .is_empty(),
+            "expected omnect_validate_extra_bootargs to be unset"
+        );
+    }
+
+    #[test]
+    fn finalize_bootargs_real_value_promotes_and_cleans_up() {
+        crate::bootloader_env::clear_mock();
+        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").expect("set extra");
+        bootloader_env::set(
+            OMNECT_VALIDATE_EXTRA_BOOTARGS,
+            "console=ttyS0,115200 loglevel=7",
+        )
+        .expect("set validate");
+
+        UpdateValidation::finalize_bootargs().expect("finalize_bootargs");
+
+        assert_eq!(
+            bootloader_env::get(OMNECT_EXTRA_BOOTARGS).expect("get extra"),
+            "console=ttyS0,115200 loglevel=7"
+        );
+        assert!(
+            bootloader_env::get(OMNECT_VALIDATE_EXTRA_BOOTARGS)
+                .expect("get validate")
+                .is_empty(),
+            "expected omnect_validate_extra_bootargs to be unset"
+        );
+    }
+
+    #[test]
+    fn finalize_bootargs_absent_validate_key_leaves_extra_untouched() {
+        crate::bootloader_env::clear_mock();
+        bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "existing_args").expect("set extra");
+        // OMNECT_VALIDATE_EXTRA_BOOTARGS intentionally not set
+
+        UpdateValidation::finalize_bootargs().expect("finalize_bootargs");
+
+        assert_eq!(
+            bootloader_env::get(OMNECT_EXTRA_BOOTARGS).expect("get extra"),
+            "existing_args",
+            "expected omnect_extra_bootargs to remain unchanged"
+        );
     }
 }

--- a/src/twin/firmware_update/update_validation.rs
+++ b/src/twin/firmware_update/update_validation.rs
@@ -197,7 +197,7 @@ impl UpdateValidation {
         }
         // else empty omnect_validate_extra bootargs -> explicitly no set of omnect_extra_bootargs
 
-        bootloader_env::unset("omnect_validate_update")?;
+        bootloader_env::unset(OMNECT_VALIDATE_UPDATE)?;
         bootloader_env::unset(OMNECT_VALIDATE_UPDATE_PART)?;
 
         fs::remove_file(UPDATE_VALIDATION_COMPLETE_BARRIER_FILE).context(format!(

--- a/src/twin/firmware_update/update_validation.rs
+++ b/src/twin/firmware_update/update_validation.rs
@@ -298,11 +298,8 @@ impl UpdateValidation {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
 
-    // Serializes finalize_bootargs tests to prevent races on the global
-    // bootloader_env mock store when cargo runs tests in parallel.
-    static BOOTARGS_TEST_LOCK: Mutex<()> = Mutex::new(());
+    use crate::bootloader_env::TEST_LOCK as BOOTARGS_TEST_LOCK;
 
     #[test]
     fn finalize_bootargs_noargs_sentinel_unsets_both_keys() {

--- a/src/twin/firmware_update/update_validation.rs
+++ b/src/twin/firmware_update/update_validation.rs
@@ -194,6 +194,7 @@ impl UpdateValidation {
             bootloader_env::set("omnect_extra_bootargs", &omnect_validate_extra_bootargs)?;
             bootloader_env::unset("omnect_validate_extra_bootargs")?;
         }
+        // else empty omnect_validate_extra bootargs -> explicitly no set of omnect_extra_bootargs
 
         bootloader_env::unset("omnect_validate_update")?;
         bootloader_env::unset("omnect_validate_update_part")?;

--- a/src/twin/firmware_update/update_validation.rs
+++ b/src/twin/firmware_update/update_validation.rs
@@ -298,9 +298,15 @@ impl UpdateValidation {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // Serializes finalize_bootargs tests to prevent races on the global
+    // bootloader_env mock store when cargo runs tests in parallel.
+    static BOOTARGS_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn finalize_bootargs_noargs_sentinel_unsets_both_keys() {
+        let _lock = BOOTARGS_TEST_LOCK.lock().unwrap();
         crate::bootloader_env::clear_mock();
         bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").expect("set extra");
         bootloader_env::set(OMNECT_VALIDATE_EXTRA_BOOTARGS, NOARGS_SENTINEL).expect("set validate");
@@ -323,6 +329,7 @@ mod tests {
 
     #[test]
     fn finalize_bootargs_real_value_promotes_and_cleans_up() {
+        let _lock = BOOTARGS_TEST_LOCK.lock().unwrap();
         crate::bootloader_env::clear_mock();
         bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "old_value").expect("set extra");
         bootloader_env::set(
@@ -347,6 +354,7 @@ mod tests {
 
     #[test]
     fn finalize_bootargs_absent_validate_key_leaves_extra_untouched() {
+        let _lock = BOOTARGS_TEST_LOCK.lock().unwrap();
         crate::bootloader_env::clear_mock();
         bootloader_env::set(OMNECT_EXTRA_BOOTARGS, "existing_args").expect("set extra");
         // OMNECT_VALIDATE_EXTRA_BOOTARGS intentionally not set

--- a/src/twin/firmware_update/update_validation.rs
+++ b/src/twin/firmware_update/update_validation.rs
@@ -186,15 +186,17 @@ impl UpdateValidation {
             "omnect_os_bootpart",
             &omnect_validate_update_part.index().to_string(),
         )?;
-        if !omnect_validate_extra_bootargs.is_empty() {
+
+        if omnect_validate_extra_bootargs == "#noargs" {
+            bootloader_env::unset("omnect_extra_bootargs")?;
+            bootloader_env::unset("omnect_validate_extra_bootargs")?;
+        } else if !omnect_validate_extra_bootargs.is_empty() {
             bootloader_env::set("omnect_extra_bootargs", &omnect_validate_extra_bootargs)?;
-        } else {
-            bootloader_env::unset("omnect_extra_bootargs,")?;
+            bootloader_env::unset("omnect_validate_extra_bootargs")?;
         }
 
         bootloader_env::unset("omnect_validate_update")?;
         bootloader_env::unset("omnect_validate_update_part")?;
-        bootloader_env::unset("omnect_validate_extra_bootargs")?;
 
         fs::remove_file(UPDATE_VALIDATION_COMPLETE_BARRIER_FILE).context(format!(
             "update validation: remove {UPDATE_VALIDATION_COMPLETE_BARRIER_FILE}"

--- a/sudo/fw_setenv_no_script.sh
+++ b/sudo/fw_setenv_no_script.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Wrapper for fw_setenv – blocks script-file mode.
+
+FW_SETENV=/usr/bin/fw_setenv
+
+usage() {
+    echo "Usage: $0 <key> <value>" >&2
+    echo "       Script-file mode is not permitted." >&2
+    exit 1
+}
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+[[ $# -ne 2 ]] && usage
+
+KEY="$1"
+VALUE="$2"
+
+# Block -s / --script anywhere in the value (as a word)
+for word in $VALUE; do
+    if [[ "$word" == "-s" || "$word" == "--script" ]]; then
+        die "Script-file mode is not allowed (flag: $word)"
+    fi
+done
+
+exec "$FW_SETENV" "$KEY" "$VALUE"

--- a/sudo/fw_setenv_no_script.sh
+++ b/sudo/fw_setenv_no_script.sh
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
 # Wrapper for fw_setenv – blocks script-file mode.
-set -uo pipefail
+set -efuo pipefail
 
 FW_SETENV=/usr/bin/fw_setenv
 

--- a/sudo/fw_setenv_no_script.sh
+++ b/sudo/fw_setenv_no_script.sh
@@ -21,8 +21,8 @@ KEY="$1"
 VALUE="$2"
 
 # Block -s / --script anywhere in the value (as a word)
-for word in $VALUE; do
-    if [[ "$word" == "-s" || "$word" == "--script" || "$word" == --script=* ]]; then
+for word in $KEY $VALUE; do
+    if [[ "$word" == "-s" || "$word" == "--script" || "$word" == -s=* || "$word" == --script=* ]]; then
         die "Script-file mode is not allowed (flag: $word)"
     fi
 done

--- a/sudo/fw_setenv_no_script.sh
+++ b/sudo/fw_setenv_no_script.sh
@@ -1,5 +1,6 @@
-#!/bin/bash
+#!/bin/bash -e
 # Wrapper for fw_setenv – blocks script-file mode.
+set -uo pipefail
 
 FW_SETENV=/usr/bin/fw_setenv
 
@@ -21,7 +22,7 @@ VALUE="$2"
 
 # Block -s / --script anywhere in the value (as a word)
 for word in $VALUE; do
-    if [[ "$word" == "-s" || "$word" == "--script" ]]; then
+    if [[ "$word" == "-s" || "$word" == "--script" || "$word" == --script=* ]]; then
         die "Script-file mode is not allowed (flag: $word)"
     fi
 done

--- a/sudo/omnect-device-service-grub
+++ b/sudo/omnect-device-service-grub
@@ -1,12 +1,12 @@
-# todo wildcard
-
 # factory reset
 # warning: using a wildcard here; options: use regex or multiple occurrences of the call with different possible input
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv set factory-reset=*
 
-# update validation finalization
+# firmware update + update validation finalization
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv set omnect_extra_bootargs=*
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv set omnect_os_bootpart=[2-3]
+# warning: using a wildcard here - the value is not static
+omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv set omnect_validate_extra_bootargs=*
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv set omnect_validate_update_part=[2-3]
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv unset omnect_extra_bootargs
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv unset omnect_validate_update

--- a/sudo/omnect-device-service-grub
+++ b/sudo/omnect-device-service-grub
@@ -5,8 +5,11 @@ omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/
 # update validation finalization
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv set omnect_os_bootpart=[2-3]
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv set omnect_validate_update_part=[2-3]
+omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv set extra_bootargs=*
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv unset omnect_validate_update
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv unset omnect_validate_update_part
+omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv unset omnect_validate_extra_bootargs
+omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv unset extra_bootargs
 
 # reboot reason logging needs root permissions with EFI variables backend, but
 # only log command is run

--- a/sudo/omnect-device-service-grub
+++ b/sudo/omnect-device-service-grub
@@ -1,3 +1,5 @@
+# todo wildcard
+
 # factory reset
 # warning: using a wildcard here; options: use regex or multiple occurrences of the call with different possible input
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv set factory-reset=*

--- a/sudo/omnect-device-service-grub
+++ b/sudo/omnect-device-service-grub
@@ -3,13 +3,13 @@
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv set factory-reset=*
 
 # update validation finalization
+omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv set omnect_extra_bootargs=*
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv set omnect_os_bootpart=[2-3]
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv set omnect_validate_update_part=[2-3]
-omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv set extra_bootargs=*
+omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv unset omnect_extra_bootargs
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv unset omnect_validate_update
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv unset omnect_validate_update_part
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv unset omnect_validate_extra_bootargs
-omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv unset extra_bootargs
 
 # reboot reason logging needs root permissions with EFI variables backend, but
 # only log command is run

--- a/sudo/omnect-device-service-uboot
+++ b/sudo/omnect-device-service-uboot
@@ -12,6 +12,8 @@ omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_printenv omnect_validate_
 # warning: using a wildcard here - the value is not static
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv_no_script.sh omnect_extra_bootargs *
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv_no_script.sh omnect_os_bootpart [2-3]
+# warning: using a wildcard here - the value is not static
+omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv_no_script.sh omnect_validate_extra_bootargs *
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv_no_script.sh omnect_validate_update_part [2-3]
 # unset:
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv omnect_extra_bootargs

--- a/sudo/omnect-device-service-uboot
+++ b/sudo/omnect-device-service-uboot
@@ -4,7 +4,11 @@ omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv factory-reset *
 
 # update validation finalization
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_printenv omnect_validate_update_part
+omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_printenv omnect_validate_extra_bootargs
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv omnect_os_bootpart [2-3]
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv omnect_validate_update
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv omnect_validate_update_part
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv omnect_validate_update_part [2-3]
+omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv omnect_validate_extra_bootargs
+omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv extra_bootargs
+omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv extra_bootargs *

--- a/sudo/omnect-device-service-uboot
+++ b/sudo/omnect-device-service-uboot
@@ -1,8 +1,11 @@
+# todo wildcard comment
+
 # factory reset
 # warning: using a wildcard here; options: use regex or multiple occurrences of the call with different possible input
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv factory-reset *
 
 # update validation finalization
+omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_printenv omnect_extra_bootargs
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_printenv omnect_validate_update_part
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_printenv omnect_validate_extra_bootargs
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv omnect_extra_bootargs

--- a/sudo/omnect-device-service-uboot
+++ b/sudo/omnect-device-service-uboot
@@ -5,10 +5,10 @@ omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv factory-reset *
 # update validation finalization
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_printenv omnect_validate_update_part
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_printenv omnect_validate_extra_bootargs
+omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv omnect_extra_bootargs
+omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv omnect_extra_bootargs *
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv omnect_os_bootpart [2-3]
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv omnect_validate_update
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv omnect_validate_update_part
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv omnect_validate_update_part [2-3]
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv omnect_validate_extra_bootargs
-omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv extra_bootargs
-omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv extra_bootargs *

--- a/sudo/omnect-device-service-uboot
+++ b/sudo/omnect-device-service-uboot
@@ -1,17 +1,20 @@
-# todo wildcard comment
+# note: use /usr/bin/fw_setenv_no_script.sh_no_script.sh wrapper instead of fw_setenv for setting.
+#       it checks if the value string includes script parameters
 
 # factory reset
 # warning: using a wildcard here; options: use regex or multiple occurrences of the call with different possible input
-omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv factory-reset *
+omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv_no_script.sh factory-reset *
 
-# update validation finalization
+# firmware update + update validation finalization
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_printenv omnect_extra_bootargs
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_printenv omnect_validate_update_part
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_printenv omnect_validate_extra_bootargs
+# warning: using a wildcard here - the value is not static
+omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv_no_script.sh omnect_extra_bootargs *
+omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv_no_script.sh omnect_os_bootpart [2-3]
+omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv_no_script.sh omnect_validate_update_part [2-3]
+# unset:
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv omnect_extra_bootargs
-omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv omnect_extra_bootargs *
-omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv omnect_os_bootpart [2-3]
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv omnect_validate_update
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv omnect_validate_update_part
-omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv omnect_validate_update_part [2-3]
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/fw_setenv omnect_validate_extra_bootargs

--- a/sudo/omnect-device-service-uboot
+++ b/sudo/omnect-device-service-uboot
@@ -1,4 +1,4 @@
-# note: use /usr/bin/fw_setenv_no_script.sh_no_script.sh wrapper instead of fw_setenv for setting.
+# note: use /usr/bin/fw_setenv_no_script.sh wrapper instead of fw_setenv for setting.
 #       it checks if the value string includes script parameters
 
 # factory reset


### PR DESCRIPTION
- firmware update handling for `omnect_extra_bootargs`
- update validation sets resp. unsets bootloader env var `omnect_extra_bootargs`
- fix accessing bootloader env vars where the value contains "="
- functional mock for bootloader_env