### PR TITLE
fix(reboot-reason): reason log didn't work in stop post script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2313,7 +2313,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-device-service"
-version = "0.41.20"
+version = "0.41.21"
 dependencies = [
  "actix-server",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-device-service"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-device-service.git"
-version = "0.41.20"
+version = "0.41.21"
 
 [dependencies]
 actix-server = { version = "2.6", default-features = false }

--- a/sudo/omnect-device-service
+++ b/sudo/omnect-device-service
@@ -7,3 +7,11 @@ omnect_device_service ALL=(ssh_tunnel_user) NOPASSWD: SSH
 
 # call swupdate with user adu (applies to any parameters)
 omnect_device_service ALL=(adu) NOPASSWD: /usr/bin/swupdate
+
+# reboot reason logging needs root permissions with EFI variables backend, but
+# only log command is run
+# NOTE:
+#   this definition is contained herein - opposed to in EFI == grub only one -
+#   because the sudo invocation is part of systemd stop post script
+#   omnect-device-service.exec_stop_post.sh which is firmware agnostic
+omnect_device_service ALL=(root) NOPASSWD: /usr/sbin/omnect_reboot_reason.sh ^log[[:space:]]+.*$

--- a/sudo/omnect-device-service-grub
+++ b/sudo/omnect-device-service-grub
@@ -7,7 +7,3 @@ omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv set omnect_validate_update_part=[2-3]
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv unset omnect_validate_update
 omnect_device_service ALL=(root) NOPASSWD: /usr/bin/grub-editenv /boot/EFI/BOOT/grubenv unset omnect_validate_update_part
-
-# reboot reason logging needs root permissions with EFI variables backend, but
-# only log command is run
-omnect_device_service ALL=(root) NOPASSWD: /usr/sbin/omnect_reboot_reason.sh ^log[[:space:]]+.*$

--- a/systemd/omnect-device-service.exec_stop_post.sh
+++ b/systemd/omnect-device-service.exec_stop_post.sh
@@ -9,7 +9,7 @@ echo SERVICE_RESULT=${SERVICE_RESULT}, EXIT_CODE=${EXIT_CODE}, EXIT_STATUS=${EXI
 
 function reboot() {
   echo "reboot triggered by ${script}: ${1}"
-  /usr/sbin/omnect_reboot_reason.sh log swupdate-validation-failed "${1}"
+  sudo /usr/sbin/omnect_reboot_reason.sh log swupdate-validation-failed "${1}"
   systemctl start reboot.target
 }
 


### PR DESCRIPTION
The omnect-device-service is run as user/group omnect_device_service which is not allowed to access EFI variables under `/sys/firmaware/efi/efivars`, where the reboot reason gets stored on UEFI devices.

So, script call of `omnect_reboot_reason.sh log ...` needs to be done via `sudo` in order to work.

Apparently, this was forgotten back when reboot reason was introduced (while still disabled due to arrakis UEFI firmware shortcomings), because the sudoers configuration already contains the necessary setting to allow the needed sudo invocation.