### PR TITLE
fix(log): route production logs directly to the systemd journal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2450,7 +2450,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-device-service"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "actix-server",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,6 +2461,7 @@ dependencies = [
  "cp_r",
  "dotenvy",
  "dynosaur",
+ "env_filter",
  "env_logger",
  "freedesktop_entry_parser",
  "futures",
@@ -2491,6 +2492,7 @@ dependencies = [
  "signal-hook-tokio",
  "strum_macros",
  "sysinfo",
+ "systemd-journal-logger",
  "systemd-zbus",
  "tar",
  "tempfile",
@@ -3516,6 +3518,16 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "windows",
+]
+
+[[package]]
+name = "systemd-journal-logger"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7266304d24ca5a4b230545fc558c80e18bd3e1d2eb1be149b6bcd04398d3e79c"
+dependencies = [
+ "log",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ sysinfo = { version = "0.38", default-features = false, features = [
   "disk",
   "system",
 ] }
-systemd-journal-logger = { version = "2.2", default-features = false }
+systemd-journal-logger = { version = "2.2", default-features = false, optional = true }
 systemd-zbus = { version = "5.3", default-features = false }
 tar = { version = "0.4", default-features = false }
 time = { version = "0.3", default-features = false, features = ["formatting"] }
@@ -83,7 +83,7 @@ tempfile = "3.22"
 
 [features]
 default = []
-bootloader_uboot = []
-bootloader_grub = []
+bootloader_uboot = ["dep:systemd-journal-logger"]
+bootloader_grub = ["dep:systemd-journal-logger"]
 mock = ["dep:env_logger"]
 modem_info = ["modemmanager"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-device-service"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-device-service.git"
-version = "0.42.1"
+version = "0.42.2"
 
 [dependencies]
 actix-server = { version = "2.6", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ azure-iot-sdk = { git = "https://github.com/omnect/azure-iot-sdk.git", tag = "0.
 base64 = { version = "0.22", default-features = false }
 dotenvy = { version = "0.15", default-features = false }
 dynosaur = { version = "0.3", default-features = false }
-env_logger = { version = "0.11", default-features = false }
+env_filter = { version = "1.0", default-features = false }
+env_logger = { version = "0.11", default-features = false, optional = true }
 freedesktop_entry_parser = { version = "1.3", default-features = false }
 futures = { version = "0.3", default-features = false }
 futures-util = { version = "0.3", default-features = false }
@@ -56,6 +57,7 @@ sysinfo = { version = "0.38", default-features = false, features = [
   "disk",
   "system",
 ] }
+systemd-journal-logger = { version = "2.2", default-features = false }
 systemd-zbus = { version = "5.3", default-features = false }
 tar = { version = "0.4", default-features = false }
 time = { version = "0.3", default-features = false, features = ["formatting"] }
@@ -83,5 +85,5 @@ tempfile = "3.22"
 default = []
 bootloader_uboot = []
 bootloader_grub = []
-mock = []
+mock = ["dep:env_logger"]
 modem_info = ["modemmanager"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod bootloader_env;
 pub mod common;
+pub mod logging;
 pub mod reboot_reason;
 pub mod systemd;
 pub mod twin;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,72 @@
+const DEFAULT_FILTER_DEBUG: &str = "warn,\
+    azure_iot_sdk=debug,\
+    eis_utils=debug,\
+    omnect_device_service=debug";
+const DEFAULT_FILTER_RELEASE: &str = "warn,\
+    azure_iot_sdk=info,\
+    eis_utils=info,\
+    omnect_device_service=info";
+
+fn default_filter() -> &'static str {
+    if cfg!(debug_assertions) {
+        DEFAULT_FILTER_DEBUG
+    } else {
+        DEFAULT_FILTER_RELEASE
+    }
+}
+
+#[cfg(feature = "mock")]
+pub fn init() {
+    use env_logger::{Builder, Env, Target};
+    use std::io::Write;
+
+    Builder::from_env(Env::default().default_filter_or(default_filter()))
+        .format(|buf, record| match record.level() {
+            log::Level::Info => writeln!(buf, "<6>{}", record.args()),
+            log::Level::Warn => writeln!(buf, "<4>{}", record.args()),
+            log::Level::Error => {
+                eprintln!("<3>{}", record.args());
+                Ok(())
+            }
+            _ => writeln!(buf, "<7>{}", record.args()),
+        })
+        .target(Target::Stdout)
+        .init();
+}
+
+#[cfg(not(feature = "mock"))]
+struct FilteredLog<L: log::Log> {
+    filter: env_filter::Filter,
+    inner: L,
+}
+
+#[cfg(not(feature = "mock"))]
+impl<L: log::Log> log::Log for FilteredLog<L> {
+    fn enabled(&self, m: &log::Metadata<'_>) -> bool {
+        self.filter.enabled(m)
+    }
+    fn log(&self, record: &log::Record<'_>) {
+        if self.filter.matches(record) {
+            self.inner.log(record);
+        }
+    }
+    fn flush(&self) {
+        self.inner.flush();
+    }
+}
+
+#[cfg(not(feature = "mock"))]
+pub fn init() {
+    use systemd_journal_logger::JournalLog;
+
+    let filter = env_filter::Builder::new().parse(default_filter()).build();
+    let max_level = filter.filter();
+
+    let journal = JournalLog::new().expect("create JournalLog");
+    log::set_boxed_logger(Box::new(FilteredLog {
+        filter,
+        inner: journal,
+    }))
+    .expect("install journal logger");
+    log::set_max_level(max_level);
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -49,7 +49,16 @@ impl<L: log::Log> log::Log for FilteredLog<L> {
         self.filter.enabled(m)
     }
     fn log(&self, record: &log::Record<'_>) {
-        if self.filter.matches(record) {
+        if !self.filter.matches(record) {
+            return;
+        }
+        if record.level() >= log::Level::Debug {
+            // Prepend target for debug/trace so interactive `journalctl -p debug`
+            // shows module origin without requiring -o verbose or jq.
+            let msg = format!("{}: {}", record.target(), record.args());
+            self.inner
+                .log(&record.to_builder().args(format_args!("{msg}")).build());
+        } else {
             self.inner.log(record);
         }
     }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -62,7 +62,11 @@ impl<L: log::Log> log::Log for FilteredLog<L> {
 pub fn init() -> Result<()> {
     use systemd_journal_logger::JournalLog;
 
-    let filter = env_filter::Builder::new().parse(default_filter()).build();
+    let filter_spec = std::env::var("RUST_LOG")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| default_filter().to_string());
+    let filter = env_filter::Builder::new().parse(&filter_spec).build();
     let max_level = filter.filter();
 
     let journal = JournalLog::new().context("create JournalLog")?;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,3 +1,5 @@
+use anyhow::{Context, Result};
+
 const DEFAULT_FILTER_DEBUG: &str = "warn,\
     azure_iot_sdk=debug,\
     eis_utils=debug,\
@@ -16,7 +18,7 @@ fn default_filter() -> &'static str {
 }
 
 #[cfg(feature = "mock")]
-pub fn init() {
+pub fn init() -> Result<()> {
     use env_logger::{Builder, Env, Target};
     use std::io::Write;
 
@@ -31,7 +33,8 @@ pub fn init() {
             _ => writeln!(buf, "<7>{}", record.args()),
         })
         .target(Target::Stdout)
-        .init();
+        .try_init()
+        .context("install env_logger")
 }
 
 #[cfg(not(feature = "mock"))]
@@ -56,17 +59,18 @@ impl<L: log::Log> log::Log for FilteredLog<L> {
 }
 
 #[cfg(not(feature = "mock"))]
-pub fn init() {
+pub fn init() -> Result<()> {
     use systemd_journal_logger::JournalLog;
 
     let filter = env_filter::Builder::new().parse(default_filter()).build();
     let max_level = filter.filter();
 
-    let journal = JournalLog::new().expect("create JournalLog");
+    let journal = JournalLog::new().context("create JournalLog")?;
     log::set_boxed_logger(Box::new(FilteredLog {
         filter,
         inner: journal,
     }))
-    .expect("install journal logger");
+    .context("install journal logger")?;
     log::set_max_level(max_level);
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,39 +1,11 @@
-use env_logger::{Builder, Env, Target};
 use log::{error, info};
-use omnect_device_service::twin::Twin;
-use std::{io::Write, process};
+use omnect_device_service::{logging, twin::Twin};
+use std::process;
 
 #[tokio::main]
 async fn main() -> process::ExitCode {
     log_panics::init();
-
-    let mut builder = if cfg!(debug_assertions) {
-        Builder::from_env(Env::default().default_filter_or(
-            "warn, \
-            azure_iot_sdk=debug, \
-            eis_utils=debug, \
-            omnect_device_service=debug",
-        ))
-    } else {
-        Builder::from_env(Env::default().default_filter_or(
-            "warn, \
-            azure_iot_sdk=info, \
-            eis_utils=info, \
-            omnect_device_service=info",
-        ))
-    };
-
-    builder.format(|buf, record| match record.level() {
-        log::Level::Info => writeln!(buf, "<6>{}: {}", record.target(), record.args()),
-        log::Level::Warn => writeln!(buf, "<4>{}: {}", record.target(), record.args()),
-        log::Level::Error => {
-            eprintln!("<3>{}: {}", record.target(), record.args());
-            Ok(())
-        }
-        _ => writeln!(buf, "<7>{}: {}", record.target(), record.args()),
-    });
-
-    builder.target(Target::Stdout).init();
+    logging::init();
 
     if let Err(e) = Twin::run().await {
         error!("application error: {e:#}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,12 @@ use std::process;
 #[tokio::main]
 async fn main() -> process::ExitCode {
     log_panics::init();
-    logging::init();
+    if let Err(e) = logging::init() {
+        // The logger is not installed; use stderr directly with a syslog
+        // priority prefix so journald still classifies it correctly.
+        eprintln!("<3>failed to initialize logger: {e:#}");
+        process::exit(1)
+    }
 
     if let Err(e) = Twin::run().await {
         error!("application error: {e:#}");


### PR DESCRIPTION
## Summary

- Replace `env_logger` with `systemd-journal-logger` for production builds; keep `env_logger` for the `mock` feature only.
- `MESSAGE` bodies lose the inline `"{target}: "` prefix; the target now lives in the structured `TARGET=` journal field.
- Move logger setup from `main.rs` into `src/logging.rs`.

## Reason

`base_test.sh` in `omnect-os/ci/tests/lib_test.sh` runs `journalctl -b -q -p err` and checks every PRIORITY≤3 line against a per-platform whitelist. It has been tripping on ods **debug** messages like:

```
omnect-device-service : omnect_device_service::twin::network: <7>omnect_device_service::twin::network: signal received, (re)arming debounce
base_test.sh: found syslog errors not in whitelist
```

### Mechanism

`env_logger` encodes severity as an in-band `"<N>"` text prefix at the start of each line. journald's `SyslogLevelPrefix` parser only accepts `"<N>"` at byte 0 — if anything precedes it, parsing fails silently and the line falls back to the stream's default priority, which on our unit config is ERROR. So a `debug!()` call lands at PRIORITY=3 and gets flagged.

We didn't identify the exact byte-perturbation source. The class of failure is inherent to in-band textual prefixes: it cannot be ruled out as long as severity travels through the MESSAGE byte stream.

### Why `systemd-journal-logger`

`systemd-journal-logger` sends records via the native sd-journal socket protocol. `PRIORITY` becomes a structured field alongside `MESSAGE`, `SYSLOG_IDENTIFIER`, and `TARGET`. It is not text, not parsed from a stream, and cannot be corrupted by concurrent writes.

### Advantages

- **Correct severity, always.** No textual prefix to lose. `journalctl -p err` only returns actual errors.
- **Structured fields for free.** `TARGET=`, `CODE_FILE=`, `CODE_LINE=`, `CODE_MODULE=` become queryable (`journalctl TARGET=omnect_device_service::twin::network`).
- **Filter semantics unchanged.** `RUST_LOG` and the same `warn,azure_iot_sdk=debug,...` defaults are preserved via `env_filter` (env_logger's filter half, published as a standalone crate).
- **Mock path untouched.** `cargo test --features mock` and `cargo run --features mock` still log to stdout through `env_logger` with the `<N>{args}` format, so test harness output stays readable.
- **Backend selection is compile-time.** Production binaries never link env_logger; mock builds never link the journal backend. The `mock` feature now implies `dep:env_logger`.