### PR TITLE
feat(reboot-reason): allow arbitrary extra info for plain reboots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2402,7 +2402,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-device-service"
-version = "0.42.5"
+version = "0.43.0"
 dependencies = [
  "actix-server",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-device-service"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-device-service.git"
-version = "0.42.5"
+version = "0.43.0"
 
 [dependencies]
 actix-server = { version = "2.6", default-features = false }

--- a/healthcheck/omnect_reboot_reason.sh
+++ b/healthcheck/omnect_reboot_reason.sh
@@ -311,7 +311,12 @@ function analyze() {
 
 	    if [ "${last_reason}" = "reboot" ]; then
 		case "${next_to_last_reason}" in
-		    swupdate | swupdate-validation-failed | factory-reset | portal-reboot | ods-reboot)
+                    # NOTE:
+                    #   we permit also the unspecific reason "reboot" as
+                    #   second-to-last reason to allow arbitrary extra
+                    #   informtion to be set, e.g. during CI/CD or also for
+                    #   customers
+		    reboot | swupdate | swupdate-validation-failed | factory-reset | portal-reboot | ods-reboot)
 			r_reason="${next_to_last_reason}"
 			r_extra_info="${next_to_last_extra_info}"
 			if [ -z "${r_extra_info}" -o "null" = "${r_extra_info}" ]; then

--- a/healthcheck/omnect_reboot_reason.sh
+++ b/healthcheck/omnect_reboot_reason.sh
@@ -330,7 +330,7 @@ function analyze() {
 		    if [ -z "${r_extra_info}" -o "null" = "${r_extra_info}" ]; then
 			r_extra_info="reboot after ${next_to_last_reason}"
 		    fi
-                fi
+		fi
 		if [ "$r_reason" ]; then
 		    # now that we determined a reboot reason, gather all other info
 		    # from last entry

--- a/healthcheck/omnect_reboot_reason.sh
+++ b/healthcheck/omnect_reboot_reason.sh
@@ -87,7 +87,18 @@
 #
 # deduced reboot reasons are:
 #  - reboot
-#    -> plain reboot without further information about who or why
+#    two possibilities exist here:
+#    1. last reason is "reboot" and either no next-to-last reason exists or
+#       is is an unrecognized reboot reason
+#       -> plain reboot without further information about who or why
+#    2. last and also next-to-last reason is "reboot"
+#       -> an intentional reboot with extra information given in next-to-last
+#          logged reboot event
+#       NOTE:
+#         any of the reasons below (but for unrecognized, of course) will
+#         void such an entry unless measures are taken that such a reboot
+#         reason is really logged as next-to-last one (systemd being regularly
+#         the last one logged)
 #  - shutdown
 #    -> shutdown; unlikely to be seen unless an external reset mechanism
 #       exists which leaves pstore intact
@@ -131,6 +142,9 @@ REASON_DFLT_DIR=/var/lib/omnect/reboot-reason
 : ${REASON_DIR:=${REASON_DFLT_DIR}}
 REASON_ANALYSIS_FILE=reboot-reason.json
 PSTORE_DFLT_DIR=/sys/fs/pstore
+
+# define supported reboot reasons
+VALID_REBOOT_REASONS=(reboot swupdate swupdate-validation-failed factory-reset portal-reboot ods-reboot)
 
 # variable below is to hold a time stamp which can be calculated once (by
 # function get_timestamp()) and used from then on to have one unique timestamp
@@ -310,20 +324,14 @@ function analyze() {
 	    next_to_last_extra_info=$(jq -rs  '[ .[] | .extra_info ] | nth('$((no_reasons - 2))')' < "${pmsg_file}")
 
 	    if [ "${last_reason}" = "reboot" ]; then
-		case "${next_to_last_reason}" in
-                    # NOTE:
-                    #   we permit also the unspecific reason "reboot" as
-                    #   second-to-last reason to allow arbitrary extra
-                    #   informtion to be set, e.g. during CI/CD or also for
-                    #   customers
-		    reboot | swupdate | swupdate-validation-failed | factory-reset | portal-reboot | ods-reboot)
-			r_reason="${next_to_last_reason}"
-			r_extra_info="${next_to_last_extra_info}"
-			if [ -z "${r_extra_info}" -o "null" = "${r_extra_info}" ]; then
-			    r_extra_info="reboot after ${next_to_last_reason}"
-			fi
+                if [[ " ${VALID_REBOOT_REASONS[*]} " =~ " ${next_to_last_reason} " ]]; then
+		    r_reason="${next_to_last_reason}"
+		    r_extra_info="${next_to_last_extra_info}"
+		    if [ -z "${r_extra_info}" -o "null" = "${r_extra_info}" ]; then
+			r_extra_info="reboot after ${next_to_last_reason}"
+		    fi
 			;;
-		esac
+                fi
 		if [ "$r_reason" ]; then
 		    # now that we determined a reboot reason, gather all other info
 		    # from last entry
@@ -949,6 +957,9 @@ if [ "${is_enabled}" = "true" ]; then
 	get)
 	    reboot_reason_get
 	    ;;
+        get_valid_reasons)
+            echo "${VALID_REBOOT_REASONS[*]}"
+            ;;
 	boottag_set)
 	    reboot_reason_boottag set "${@:2}"
 	    ;;

--- a/healthcheck/omnect_reboot_reason.sh
+++ b/healthcheck/omnect_reboot_reason.sh
@@ -958,6 +958,8 @@ if [ "${is_enabled}" = "true" ]; then
 	    reboot_reason_get
 	    ;;
         get_valid_reasons)
+            # simply print a space separated list in one line
+            # (for easy word-wise regexp matching by a caller)
             echo "${VALID_REBOOT_REASONS[*]}"
             ;;
 	boottag_set)

--- a/healthcheck/omnect_reboot_reason.sh
+++ b/healthcheck/omnect_reboot_reason.sh
@@ -330,7 +330,6 @@ function analyze() {
 		    if [ -z "${r_extra_info}" -o "null" = "${r_extra_info}" ]; then
 			r_extra_info="reboot after ${next_to_last_reason}"
 		    fi
-			;;
                 fi
 		if [ "$r_reason" ]; then
 		    # now that we determined a reboot reason, gather all other info

--- a/healthcheck/omnect_reboot_reason.sh
+++ b/healthcheck/omnect_reboot_reason.sh
@@ -324,7 +324,7 @@ function analyze() {
 	    next_to_last_extra_info=$(jq -rs  '[ .[] | .extra_info ] | nth('$((no_reasons - 2))')' < "${pmsg_file}")
 
 	    if [ "${last_reason}" = "reboot" ]; then
-                if [[ " ${VALID_REBOOT_REASONS[*]} " =~ " ${next_to_last_reason} " ]]; then
+		if [[ " ${VALID_REBOOT_REASONS[*]} " =~ " ${next_to_last_reason} " ]]; then
 		    r_reason="${next_to_last_reason}"
 		    r_extra_info="${next_to_last_extra_info}"
 		    if [ -z "${r_extra_info}" -o "null" = "${r_extra_info}" ]; then


### PR DESCRIPTION
Previously, whenever the last logged reboot reason was a plain reboot
then the next-to-last reason logged was considered to contain the real
cause.

These causes were restricted to well-known reboot reasons used by the
system itself like swupdate or factory-reset.

However, for testing purposes or maybe even for customers it can be
helpful to log some extra information for an intentional reboot.

This is now implemented by using reboot cause "reboot" for main reason
and provide extra information as appropriate for the reboot about to
take place.

Signed-off-by: Harry Waschkeit <44188360+HarryWaschkeit@users.noreply.github.com>