### PR TITLE
fix(factory_reset): adapt result parsing to omnect-os-init JSON contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-device-service"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "actix-server",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-device-service"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-device-service.git"
-version = "0.44.1"
+version = "0.44.2"
 
 [dependencies]
 actix-server = { version = "2.6", default-features = false }

--- a/README.md
+++ b/README.md
@@ -277,13 +277,12 @@ In all other cases there will be an error status and a meaningful message in the
 #### Report factory reset result
 
 Performing a factory reset also triggers a device restart. The restart duration might depend on the selected factory reset mode. After the device has been restarted, the result is reported in the module twin.
-Details about the result format can be found [here](https://github.com/omnect/meta-omnect#factory-reset).
+The result format is defined by [omnect-os-init](https://github.com/omnect/omnect-os-init).
 
 ```json
 "factory_reset":
 {
   "result": {
-      "error": "0",
       "paths": [
           "/etc/omnect/factory-reset.d/"
       ],
@@ -291,6 +290,8 @@ Details about the result format can be found [here](https://github.com/omnect/me
   }
 }
 ```
+
+`error` and `context` are optional strings; they are only reported when present in the factory reset result. A status code unknown to the service is reported as `4294967295` (unknown).
 
 ### iot-hub-device-update user consent
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,9 @@ The result format is defined by [omnect-os-init](https://github.com/omnect/omnec
 "factory_reset":
 {
   "result": {
+      "context": null,
+      "data_wiped": true,
+      "error": null,
       "paths": [
           "/etc/omnect/factory-reset.d/"
       ],
@@ -291,7 +294,10 @@ The result format is defined by [omnect-os-init](https://github.com/omnect/omnec
 }
 ```
 
-`error` and `context` are optional strings; they are only reported when present in the factory reset result. A status code unknown to the service is reported as `4294967295` (unknown).
+- `status`: `0` success, `1` invalid request, `2` error, `3` configuration error, `4` warning (reset succeeded, but a partition needed a second format attempt). A status code unknown to the service is reported as `4294967295`.
+- `error` and `context` are `null` unless the reset reported a problem.
+- `paths` lists the preserved paths.
+- `data_wiped` is `true` once the reset started wiping data; on `status` `2` it distinguishes a safe abort from a failure after data was already wiped.
 
 ### iot-hub-device-update user consent
 

--- a/src/twin/factory_reset.rs
+++ b/src/twin/factory_reset.rs
@@ -67,25 +67,31 @@ pub struct CustomConfig {
 #[derive(Debug, Deserialize_repr, PartialEq, Serialize_repr)]
 #[repr(u32)]
 pub enum FactoryResetStatus {
-    ModeSupported = 0,
-    ModeUnsupported = 1,
-    BackupRestoreError = 2,
-    ConfigurationError = 3,
+    Success = 0,
+    Invalid = 1,
+    Error = 2,
+    ConfigError = 3,
     Warning = 4,
     // catch-all so a future status code doesn't fail parsing and ODS startup
     #[serde(other)]
     Unknown = u32::MAX,
 }
 
+// absent options serialize as null: twin reports are merge patches, so an
+// omitted key would keep the value of a previous result
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 struct FactoryResetResult {
     status: FactoryResetStatus,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     context: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     error: Option<String>,
     #[serde(default)]
     paths: Vec<String>,
+    // true once the destructive phase began; distinguishes a safe abort from
+    // a failure after data was already wiped
+    #[serde(default)]
+    data_wiped: bool,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
@@ -346,10 +352,11 @@ mod tests {
         assert_eq!(
             reported,
             FactoryResetResult {
-                status: FactoryResetStatus::ModeSupported,
+                status: FactoryResetStatus::Success,
                 error: None,
                 context: None,
                 paths: vec![],
+                data_wiped: true,
             }
         );
     }
@@ -419,10 +426,11 @@ mod tests {
         assert_eq!(
             FactoryReset::factory_reset_result().unwrap().unwrap(),
             FactoryResetResult {
-                status: FactoryResetStatus::ModeSupported,
+                status: FactoryResetStatus::Success,
                 error: None,
                 paths: vec![],
                 context: None,
+                data_wiped: true,
             }
         );
 
@@ -436,9 +444,10 @@ mod tests {
                 .expect("warning result present"),
             FactoryResetResult {
                 status: FactoryResetStatus::Warning,
-                error: Some("partition needed a second mkfs".to_string()),
-                paths: vec!["/data/foo".to_string()],
-                context: Some("format data partition".to_string()),
+                error: None,
+                paths: vec!["network".to_string()],
+                context: Some("reformat retried for: data".to_string()),
+                data_wiped: true,
             }
         );
 
@@ -449,9 +458,14 @@ mod tests {
         assert_eq!(
             FactoryReset::factory_reset_result()
                 .expect("parse unknown status result")
-                .expect("unknown status result present")
-                .status,
-            FactoryResetStatus::Unknown
+                .expect("unknown status result present"),
+            FactoryResetResult {
+                status: FactoryResetStatus::Unknown,
+                error: Some("error of a future status code".to_string()),
+                paths: vec![],
+                context: None,
+                data_wiped: false,
+            }
         );
 
         crate::common::set_env_var(
@@ -459,6 +473,40 @@ mod tests {
             "testfiles/positive/omnect-os-initramfs-normal-boot.json",
         );
         assert!(FactoryReset::factory_reset_result().unwrap().is_none());
+
+        crate::common::set_env_var(
+            "FACTORY_RESET_RESULT_FILE_PATH",
+            "testfiles/positive/omnect-os-initramfs-factory-reset-null.json",
+        );
+        assert!(
+            FactoryReset::factory_reset_result()
+                .expect("parse null result")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn factory_reset_new_with_unknown_status_test() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let config_file_path = temp_dir.path().join("factory-reset.json");
+        let custom_dir_path = temp_dir.path().join("factory-reset.d");
+
+        std::fs::copy(
+            "testfiles/positive/factory-reset.json",
+            config_file_path.clone().as_path(),
+        )
+        .expect("copy config");
+        std::fs::create_dir_all(custom_dir_path.clone()).expect("create custom dir");
+
+        crate::common::set_env_var(
+            "FACTORY_RESET_RESULT_FILE_PATH",
+            "testfiles/positive/omnect-os-initramfs-factory-reset-unknown-status.json",
+        );
+        crate::common::set_env_var("FACTORY_RESET_CONFIG_FILE_PATH", config_file_path);
+        crate::common::set_env_var("FACTORY_RESET_CUSTOM_CONFIG_DIR_PATH", custom_dir_path);
+
+        let mut fs_watcher = FsWatcher::new().expect("FsWatcher::new");
+        assert!(FactoryReset::new(&mut fs_watcher).is_ok());
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/twin/factory_reset.rs
+++ b/src/twin/factory_reset.rs
@@ -72,7 +72,7 @@ pub enum FactoryResetStatus {
     Error = 2,
     ConfigError = 3,
     Warning = 4,
-    // catch-all so a future status code doesn't fail parsing and ODS startup
+    // a future status code must parse instead of failing ODS startup
     #[serde(other)]
     Unknown = u32::MAX,
 }

--- a/src/twin/factory_reset.rs
+++ b/src/twin/factory_reset.rs
@@ -63,21 +63,28 @@ pub struct CustomConfig {
     paths: Vec<String>,
 }
 
+// u32 matches the serialization in omnect-os-init
 #[derive(Debug, Deserialize_repr, PartialEq, Serialize_repr)]
-#[repr(u8)]
+#[repr(u32)]
 pub enum FactoryResetStatus {
     ModeSupported = 0,
     ModeUnsupported = 1,
     BackupRestoreError = 2,
     ConfigurationError = 3,
+    Warning = 4,
+    // catch-all so a future status code doesn't fail parsing and ODS startup
+    #[serde(other)]
+    Unknown = u32::MAX,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 struct FactoryResetResult {
     status: FactoryResetStatus,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     context: Option<String>,
-    error: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    #[serde(default)]
     paths: Vec<String>,
 }
 
@@ -177,7 +184,7 @@ impl Feature for FactoryReset {
 }
 
 impl FactoryReset {
-    const FACTORY_RESET_VERSION: u8 = 3;
+    const FACTORY_RESET_VERSION: u8 = 4;
     const ID: &'static str = "factory_reset";
 
     pub fn new(fs_watcher: &mut FsWatcher) -> Result<Self> {
@@ -232,13 +239,21 @@ impl FactoryReset {
     fn factory_reset_result() -> Result<Option<FactoryResetResult>> {
         let omnect_os_initramfs_json: serde_json::Value = from_json_file(result_path!())?;
 
-        if omnect_os_initramfs_json["factory-reset"].is_null() {
+        if omnect_os_initramfs_json["factory_reset"].is_null() {
             debug!("factory reset: no result");
             return Ok(None);
         }
 
-        let result = serde_json::from_value(omnect_os_initramfs_json["factory-reset"].clone())
-            .context("failed to parse factory reset result from initramfs")?;
+        let result: FactoryResetResult =
+            serde_json::from_value(omnect_os_initramfs_json["factory_reset"].clone())
+                .context("failed to parse factory reset result from initramfs")?;
+
+        if result.status == FactoryResetStatus::Unknown {
+            warn!(
+                "factory reset result with unknown status: {:#}",
+                omnect_os_initramfs_json["factory_reset"]
+            );
+        }
 
         info!("factory reset result: {result:#?}");
 
@@ -332,7 +347,7 @@ mod tests {
             reported,
             FactoryResetResult {
                 status: FactoryResetStatus::ModeSupported,
-                error: "-".to_string(),
+                error: None,
                 context: None,
                 paths: vec![],
             }
@@ -405,10 +420,38 @@ mod tests {
             FactoryReset::factory_reset_result().unwrap().unwrap(),
             FactoryResetResult {
                 status: FactoryResetStatus::ModeSupported,
-                error: "-".to_string(),
+                error: None,
                 paths: vec![],
                 context: None,
             }
+        );
+
+        crate::common::set_env_var(
+            "FACTORY_RESET_RESULT_FILE_PATH",
+            "testfiles/positive/omnect-os-initramfs-factory-reset-warning.json",
+        );
+        assert_eq!(
+            FactoryReset::factory_reset_result()
+                .expect("parse warning result")
+                .expect("warning result present"),
+            FactoryResetResult {
+                status: FactoryResetStatus::Warning,
+                error: Some("partition needed a second mkfs".to_string()),
+                paths: vec!["/data/foo".to_string()],
+                context: Some("format data partition".to_string()),
+            }
+        );
+
+        crate::common::set_env_var(
+            "FACTORY_RESET_RESULT_FILE_PATH",
+            "testfiles/positive/omnect-os-initramfs-factory-reset-unknown-status.json",
+        );
+        assert_eq!(
+            FactoryReset::factory_reset_result()
+                .expect("parse unknown status result")
+                .expect("unknown status result present")
+                .status,
+            FactoryResetStatus::Unknown
         );
 
         crate::common::set_env_var(

--- a/src/twin/mod_test.rs
+++ b/src/twin/mod_test.rs
@@ -310,7 +310,7 @@ pub mod mod_test {
             mock.expect_twin_report()
                 .with(eq(json!({
                     "device_update_consent": {"version": 1},
-                    "factory_reset": {"version": 3},
+                    "factory_reset": {"version": 4},
                     "firmware_update": {"version": 1},
                     "modem_info": null,
                     "network_status": {"version": 3},
@@ -414,7 +414,6 @@ pub mod mod_test {
                     "factory_reset": {
                         "keys": vec!["certificates", "firewall", "network"],
                         "result": {
-                            "error": "-",
                             "paths": [],
                             "status": 0,
                         },

--- a/src/twin/mod_test.rs
+++ b/src/twin/mod_test.rs
@@ -414,6 +414,9 @@ pub mod mod_test {
                     "factory_reset": {
                         "keys": vec!["certificates", "firewall", "network"],
                         "result": {
+                            "context": null,
+                            "data_wiped": true,
+                            "error": null,
                             "paths": [],
                             "status": 0,
                         },

--- a/testfiles/negative/omnect-os-initramfs-factory-reset-format.json
+++ b/testfiles/negative/omnect-os-initramfs-factory-reset-format.json
@@ -1,6 +1,5 @@
 {
-    "fsck": {},
-    "factory-reset": {
+    "factory_reset": {
         "status": "wrong",
         "error": "format"
     }

--- a/testfiles/positive/omnect-os-initramfs-factory-reset-null.json
+++ b/testfiles/positive/omnect-os-initramfs-factory-reset-null.json
@@ -1,0 +1,4 @@
+{
+    "factory_reset": null,
+    "first_boot": false
+}

--- a/testfiles/positive/omnect-os-initramfs-factory-reset-unknown-status.json
+++ b/testfiles/positive/omnect-os-initramfs-factory-reset-unknown-status.json
@@ -1,7 +1,7 @@
 {
     "factory_reset": {
-        "status": 0,
-        "data_wiped": true
+        "status": 300,
+        "data_wiped": false
     },
     "first_boot": false
 }

--- a/testfiles/positive/omnect-os-initramfs-factory-reset-unknown-status.json
+++ b/testfiles/positive/omnect-os-initramfs-factory-reset-unknown-status.json
@@ -1,6 +1,7 @@
 {
     "factory_reset": {
         "status": 300,
+        "error": "error of a future status code",
         "data_wiped": false
     },
     "first_boot": false

--- a/testfiles/positive/omnect-os-initramfs-factory-reset-warning.json
+++ b/testfiles/positive/omnect-os-initramfs-factory-reset-warning.json
@@ -1,10 +1,9 @@
 {
     "factory_reset": {
         "status": 4,
-        "error": "partition needed a second mkfs",
-        "context": "format data partition",
+        "context": "reformat retried for: data",
         "paths": [
-            "/data/foo"
+            "network"
         ],
         "data_wiped": true
     },

--- a/testfiles/positive/omnect-os-initramfs-factory-reset-warning.json
+++ b/testfiles/positive/omnect-os-initramfs-factory-reset-warning.json
@@ -1,0 +1,12 @@
+{
+    "factory_reset": {
+        "status": 4,
+        "error": "partition needed a second mkfs",
+        "context": "format data partition",
+        "paths": [
+            "/data/foo"
+        ],
+        "data_wiped": true
+    },
+    "first_boot": false
+}

--- a/testfiles/positive/omnect-os-initramfs-normal-boot.json
+++ b/testfiles/positive/omnect-os-initramfs-normal-boot.json
@@ -1,4 +1,3 @@
 {
-    "fsck": {},
-    "factory-reset": null
+    "first_boot": false
 }


### PR DESCRIPTION
Closes #205

## Summary

Adapt the factory-reset result parsing to the JSON that omnect-os-init writes to `/run/omnect-device-service/omnect-os-initramfs.json`:

- read key `factory_reset` (was `factory-reset`)
- new status `4` (warning: reset ok, but a partition needed a second `mkfs`)
- `error`, `context` and `paths` are optional with defaults
- a future unknown status code parses as `Unknown` (reported as `u32::MAX`) instead of failing ODS startup; the raw result is logged as warning
- status is `u32` to match the omnect-os-init serialization (`serialize_u32`), so even a code > 255 cannot break startup
- status variants renamed to the omnect-os-init names (wire format unchanged; the old names described the codes wrongly in logs)
- report `data_wiped`: on error it distinguishes a safe abort from a failure after data was already wiped
- report `error` and `context` as `null` instead of omitting them: twin reports are merge patches, so an omitted key would keep the value of a previous result
- feature version bumped 3 -> 4 because the reported result shape changed
- testfiles updated to the real omnect-os-init output shape; result fields documented in the README

## Reason

The parser and the omnect-os-init contract did not match, so the factory-reset result never reached the twin. After fixing only the key, a `status: 4` or a missing `error`/`paths` would have failed `FactoryReset::new()` and with it ODS startup. See #205 for the full mismatch table.

## Follow-up

omnect-ui deserializes the published result with a required `error` field and status `0..=3` only, so it cannot parse the new shape (including the normal successful reset): omnect/omnect-ui#125
