### PR TITLE
fix(sudo): block all fw_setenv options, not only -s/--script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-device-service"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "actix-server",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-device-service"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-device-service.git"
-version = "0.45.0"
+version = "0.45.1"
 
 [dependencies]
 actix-server = { version = "2.6", default-features = false }

--- a/project-context.md
+++ b/project-context.md
@@ -61,11 +61,11 @@
 
 ## 4. Repository-Specific Constraints
 
-- **Mutually exclusive feature flags:** Exactly one of `bootloader_grub`, `bootloader_uboot`, or `mock` must be active. The `mock` feature stubs out hardware/systemd interactions for testing.
+- **Mutually exclusive feature flags:** Exactly one of `bootloader_grub`, `bootloader_uboot`, or `mock` must be active. The `mock` feature stubs out hardware/systemd interactions for testing. `Cargo.toml` declares a self dev-dependency with `features = ["mock"]`, so any command covering test targets already pulls `mock` in — pair `--all-targets` with `mock`, or `src/build.rs` rejects the combination.
 - **Feature trait pattern:** Every device capability implements the `Feature` trait (in its own `src/twin/*.rs` module). Adding a new feature means: (1) implement `Feature`, (2) add a `Command` variant, (3) register in `Twin::new()` feature map.
 - **Command dispatch:** All operations flow through the `Command` enum and parsing helpers in `src/twin/feature/command.rs`, with file-watch handling in `fs_watcher.rs`. Direct methods, desired properties, file-system events, and intervals all produce `Command` values that get routed to the owning feature via `TypeId`.
 - **Web service publish pattern:** Features publish state via `web_service::publish(PublishChannel, value)`. External consumers register endpoints in `/run/omnect-device-service/publish_endpoints.json`.
-- **Test location:** Unit tests live in a `#[cfg(test)] mod`, either inline in the file under test or in a sibling `*_test.rs` pulled in with `#[path]`. `tests/` is only for what has no Rust module to attach to, such as the shell wrappers in `sudo/`.
+- **Test location:** Unit tests live in an inline `#[cfg(test)] mod tests` in the file under test. `src/twin/mod.rs` is the one exception and keeps them in a sibling `mod_test.rs` via `#[path]`. `tests/` is only for what has no Rust module to attach to, such as the shell wrappers in `sudo/`.
 - **`#[cfg(test)]` IoT Hub mock:** In test builds, `Twin` uses `MockMyIotHub` (generated via `mockall`) instead of the real `IotHubClient`. See `src/twin/mod_test.rs`.
 - **Privileged operations:** The service runs unprivileged but uses sudoers rules (`sudo/`) and polkit (`polkit/`) for specific operations (grub-editenv, fw_setenv, journalctl, reboot).
 - **`modem_info` feature:** Opt-in via the `modem_info` Cargo feature (pulls in the `modemmanager` crate). Not active by default.
@@ -75,9 +75,9 @@
 - **Build (non-mock):** `cargo build --features bootloader_grub`
 - **Build (mock/test):** `cargo build --features mock`
 - **Run Tests:** `cargo test --features mock`
-- **Lint:** `cargo clippy --features bootloader_grub -- -D warnings`
+- **Lint:** `cargo clippy --features bootloader_grub -- -D warnings` and `cargo clippy --features mock --all-targets -- -D warnings`
 - **Format:** `cargo fmt`
-- **Pre-commit check:** `cargo fmt && cargo clippy --features bootloader_grub -- -D warnings` (must pass before committing)
+- **Pre-commit check:** `cargo fmt && cargo clippy --features bootloader_grub -- -D warnings && cargo clippy --features mock --all-targets -- -D warnings` (must pass before committing)
 
 ## 6. Global Rule Overrides
 

--- a/project-context.md
+++ b/project-context.md
@@ -65,7 +65,7 @@
 - **Feature trait pattern:** Every device capability implements the `Feature` trait (in its own `src/twin/*.rs` module). Adding a new feature means: (1) implement `Feature`, (2) add a `Command` variant, (3) register in `Twin::new()` feature map.
 - **Command dispatch:** All operations flow through the `Command` enum and parsing helpers in `src/twin/feature/command.rs`, with file-watch handling in `fs_watcher.rs`. Direct methods, desired properties, file-system events, and intervals all produce `Command` values that get routed to the owning feature via `TypeId`.
 - **Web service publish pattern:** Features publish state via `web_service::publish(PublishChannel, value)`. External consumers register endpoints in `/run/omnect-device-service/publish_endpoints.json`.
-- **Test location:** Unit tests live in a `#[cfg(test)] mod` inside the file under test. `tests/` is only for what has no Rust module to attach to, such as the shell wrappers in `sudo/`.
+- **Test location:** Unit tests live in a `#[cfg(test)] mod`, either inline in the file under test or in a sibling `*_test.rs` pulled in with `#[path]`. `tests/` is only for what has no Rust module to attach to, such as the shell wrappers in `sudo/`.
 - **`#[cfg(test)]` IoT Hub mock:** In test builds, `Twin` uses `MockMyIotHub` (generated via `mockall`) instead of the real `IotHubClient`. See `src/twin/mod_test.rs`.
 - **Privileged operations:** The service runs unprivileged but uses sudoers rules (`sudo/`) and polkit (`polkit/`) for specific operations (grub-editenv, fw_setenv, journalctl, reboot).
 - **`modem_info` feature:** Opt-in via the `modem_info` Cargo feature (pulls in the `modemmanager` crate). Not active by default.

--- a/project-context.md
+++ b/project-context.md
@@ -57,7 +57,7 @@
 - `sudo/` — sudoers drop-in files granting the service permission for specific privileged commands
 - `polkit/` — polkit rules for D-Bus permissions
 - `testfiles/` — test fixtures (positive/negative cases, Wi-Fi commissioning configs)
-- `tests/` — integration tests for things with no Rust module to live in, e.g. the shell wrappers in `sudo/`; everything else is tested in a `#[cfg(test)] mod` inside the file under test
+- `tests/` — integration tests for things with no Rust module to live in, e.g. the shell wrappers in `sudo/`
 
 ## 4. Repository-Specific Constraints
 
@@ -65,6 +65,7 @@
 - **Feature trait pattern:** Every device capability implements the `Feature` trait (in its own `src/twin/*.rs` module). Adding a new feature means: (1) implement `Feature`, (2) add a `Command` variant, (3) register in `Twin::new()` feature map.
 - **Command dispatch:** All operations flow through the `Command` enum and parsing helpers in `src/twin/feature/command.rs`, with file-watch handling in `fs_watcher.rs`. Direct methods, desired properties, file-system events, and intervals all produce `Command` values that get routed to the owning feature via `TypeId`.
 - **Web service publish pattern:** Features publish state via `web_service::publish(PublishChannel, value)`. External consumers register endpoints in `/run/omnect-device-service/publish_endpoints.json`.
+- **Test location:** Unit tests live in a `#[cfg(test)] mod` inside the file under test. `tests/` is only for what has no Rust module to attach to, such as the shell wrappers in `sudo/`.
 - **`#[cfg(test)]` IoT Hub mock:** In test builds, `Twin` uses `MockMyIotHub` (generated via `mockall`) instead of the real `IotHubClient`. See `src/twin/mod_test.rs`.
 - **Privileged operations:** The service runs unprivileged but uses sudoers rules (`sudo/`) and polkit (`polkit/`) for specific operations (grub-editenv, fw_setenv, journalctl, reboot).
 - **`modem_info` feature:** Opt-in via the `modem_info` Cargo feature (pulls in the `modemmanager` crate). Not active by default.

--- a/project-context.md
+++ b/project-context.md
@@ -57,6 +57,7 @@
 - `sudo/` — sudoers drop-in files granting the service permission for specific privileged commands
 - `polkit/` — polkit rules for D-Bus permissions
 - `testfiles/` — test fixtures (positive/negative cases, Wi-Fi commissioning configs)
+- `tests/` — integration tests for things with no Rust module to live in, e.g. the shell wrappers in `sudo/`; everything else is tested in a `#[cfg(test)] mod` inside the file under test
 
 ## 4. Repository-Specific Constraints
 

--- a/sudo/fw_setenv_no_script.sh
+++ b/sudo/fw_setenv_no_script.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Wrapper for fw_setenv – blocks script-file mode.
+# Wrapper for fw_setenv – blocks options, especially script-file mode.
 set -efuo pipefail
 
 FW_SETENV=/usr/bin/fw_setenv
@@ -10,21 +10,13 @@ usage() {
     exit 1
 }
 
-die() {
-    echo "ERROR: $*" >&2
-    exit 1
-}
-
 [[ $# -ne 2 ]] && usage
 
 KEY="$1"
 VALUE="$2"
 
-# Block -s / --script anywhere in the value (as a word)
-for word in $KEY $VALUE; do
-    if [[ "$word" == "-s" || "$word" == "--script" || "$word" == -s=* || "$word" == --script=* ]]; then
-        die "Script-file mode is not allowed (flag: $word)"
-    fi
-done
-
-exec "$FW_SETENV" "$KEY" "$VALUE"
+# '--' ends option parsing, so key and value are always treated as data.
+# this blocks script mode and every other option, e.g. an attacker-chosen
+# config file, which a flag blocklist would miss (getopt accepts attached
+# values like -sFILE and abbreviations like --scr=FILE)
+exec "$FW_SETENV" -- "$KEY" "$VALUE"

--- a/sudo/fw_setenv_no_script.sh
+++ b/sudo/fw_setenv_no_script.sh
@@ -6,17 +6,16 @@ FW_SETENV=/usr/bin/fw_setenv
 
 usage() {
     echo "Usage: $0 <key> <value>" >&2
-    echo "       Script-file mode is not permitted." >&2
     exit 1
 }
 
+# sudo matches command line arguments as one concatenated string, so a wildcard
+# rule can pass more than the two expected arguments
 [[ $# -ne 2 ]] && usage
 
 KEY="$1"
 VALUE="$2"
 
-# '--' ends option parsing, so key and value are always treated as data.
-# this blocks script mode and every other option, e.g. an attacker-chosen
-# config file, which a flag blocklist would miss (getopt accepts attached
-# values like -sFILE and abbreviations like --scr=FILE)
+# fw_setenv parses with getopt, which also accepts -sFILE and --scr=FILE,
+# so '--' is what keeps key and value as data
 exec "$FW_SETENV" -- "$KEY" "$VALUE"

--- a/sudo/omnect-device-service-uboot
+++ b/sudo/omnect-device-service-uboot
@@ -1,5 +1,5 @@
 # note: use /usr/bin/fw_setenv_no_script.sh wrapper instead of fw_setenv for setting.
-#       it checks if the value string includes script parameters
+#       it ends option parsing, so key and value can never become fw_setenv options
 
 # factory reset
 # warning: using a wildcard here; options: use regex or multiple occurrences of the call with different possible input

--- a/sudo/omnect-device-service-uboot
+++ b/sudo/omnect-device-service-uboot
@@ -1,5 +1,6 @@
 # note: use /usr/bin/fw_setenv_no_script.sh wrapper instead of fw_setenv for setting.
-#       it ends option parsing, so key and value can never become fw_setenv options
+#       it ends option parsing and rejects anything other than exactly two
+#       arguments, so key and value can never become fw_setenv options
 
 # factory reset
 # warning: using a wildcard here; options: use regex or multiple occurrences of the call with different possible input

--- a/tests/fw_setenv_wrapper.rs
+++ b/tests/fw_setenv_wrapper.rs
@@ -1,0 +1,127 @@
+//! Argument contract of the fw_setenv wrapper: key and value must always reach
+//! fw_setenv as data. The wrapper is exercised with a stub instead of the real
+//! binary, so the test asserts the argument vector, not libubootenv's parsing.
+
+use std::{
+    fs,
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+use tempfile::TempDir;
+
+const WRAPPER_SRC: &str = "sudo/fw_setenv_no_script.sh";
+const FW_SETENV_ASSIGNMENT: &str = "FW_SETENV=/usr/bin/fw_setenv";
+const STUB_SRC: &str = "#!/bin/bash\nprintf '[%s]\\n' \"$@\"\n";
+const EXECUTABLE_MODE: u32 = 0o755;
+const USAGE_EXIT_CODE: i32 = 1;
+
+fn write_executable(path: &Path, content: &str) {
+    fs::write(path, content).expect("write script");
+    fs::set_permissions(path, fs::Permissions::from_mode(EXECUTABLE_MODE)).expect("chmod script");
+}
+
+/// Copies the wrapper into `dir` with `FW_SETENV` pointing at a stub that dumps its arguments.
+fn wrapper_with_stub(dir: &Path) -> PathBuf {
+    let stub = dir.join("fw_setenv_stub");
+    write_executable(&stub, STUB_SRC);
+
+    let source = fs::read_to_string(WRAPPER_SRC).expect("read wrapper");
+    assert!(
+        source.contains(FW_SETENV_ASSIGNMENT),
+        "{WRAPPER_SRC} no longer contains \"{FW_SETENV_ASSIGNMENT}\""
+    );
+
+    let wrapper = dir.join("fw_setenv_no_script.sh");
+    write_executable(
+        &wrapper,
+        &source.replace(
+            FW_SETENV_ASSIGNMENT,
+            &format!("FW_SETENV={}", stub.display()),
+        ),
+    );
+    wrapper
+}
+
+fn run(args: &[&str]) -> Output {
+    let dir = TempDir::new().expect("temp dir");
+    Command::new(wrapper_with_stub(dir.path()))
+        .args(args)
+        .output()
+        .expect("run wrapper")
+}
+
+fn forwarded_args(key: &str, value: &str) -> Vec<String> {
+    let output = run(&[key, value]);
+    assert!(
+        output.status.success(),
+        "wrapper failed for [{key}] [{value}]: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("stub output is utf8")
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+fn expected_args(key: &str, value: &str) -> Vec<String> {
+    vec!["[--]".to_string(), format!("[{key}]"), format!("[{value}]")]
+}
+
+#[test]
+fn key_and_value_are_forwarded_behind_double_dash() {
+    assert_eq!(
+        forwarded_args("factory-reset", "1"),
+        expected_args("factory-reset", "1")
+    );
+}
+
+#[test]
+fn option_like_value_stays_data() {
+    for value in [
+        "-s/tmp/evil",
+        "--script=/tmp/evil",
+        "--scr=/tmp/evil",
+        "-c/tmp/evil.conf",
+    ] {
+        assert_eq!(
+            forwarded_args("omnect_extra_bootargs", value),
+            expected_args("omnect_extra_bootargs", value),
+            "value {value} was not forwarded as data"
+        );
+    }
+}
+
+#[test]
+fn option_like_key_stays_data() {
+    assert_eq!(
+        forwarded_args("--scr=/tmp/evil", "1"),
+        expected_args("--scr=/tmp/evil", "1")
+    );
+}
+
+#[test]
+fn wrong_argument_count_is_rejected() {
+    for args in [
+        vec![],
+        vec!["only-a-key"],
+        vec!["key", "value", "surplus"],
+        vec!["key", "value", "-s/tmp/evil"],
+    ] {
+        let output = run(&args);
+        assert_eq!(
+            output.status.code(),
+            Some(USAGE_EXIT_CODE),
+            "unexpected exit code for {args:?}"
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("Usage:"),
+            "no usage message for {args:?}"
+        );
+        assert!(
+            output.stdout.is_empty(),
+            "fw_setenv was called for {args:?}"
+        );
+    }
+}

--- a/tests/fw_setenv_wrapper.rs
+++ b/tests/fw_setenv_wrapper.rs
@@ -110,9 +110,8 @@ fn value_with_spaces_stays_one_argument() {
     );
 }
 
-/// An empty value must still be forwarded, otherwise the call turns into a delete.
 #[test]
-fn empty_value_is_forwarded() {
+fn empty_value_is_forwarded_instead_of_deleting() {
     assert_eq!(
         forwarded_args("omnect_extra_bootargs", ""),
         expected_args("omnect_extra_bootargs", "")

--- a/tests/fw_setenv_wrapper.rs
+++ b/tests/fw_setenv_wrapper.rs
@@ -1,6 +1,6 @@
 //! Argument contract of the fw_setenv wrapper: key and value must always reach
 //! fw_setenv as data. The wrapper is exercised with a stub instead of the real
-//! binary, so the test asserts the argument vector, not libubootenv's parsing.
+//! binary, so the test asserts the argument vector.
 
 use std::{
     fs,
@@ -98,6 +98,24 @@ fn option_like_key_stays_data() {
     assert_eq!(
         forwarded_args("--scr=/tmp/evil", "1"),
         expected_args("--scr=/tmp/evil", "1")
+    );
+}
+
+#[test]
+fn value_with_spaces_stays_one_argument() {
+    let value = "console=ttyS0 root=/dev/sda2";
+    assert_eq!(
+        forwarded_args("omnect_extra_bootargs", value),
+        expected_args("omnect_extra_bootargs", value)
+    );
+}
+
+/// An empty value must still be forwarded, otherwise the call turns into a delete.
+#[test]
+fn empty_value_is_forwarded() {
+    assert_eq!(
+        forwarded_args("omnect_extra_bootargs", ""),
+        expected_args("omnect_extra_bootargs", "")
     );
 }
 


### PR DESCRIPTION
## Summary
Pass `--` to `fw_setenv` so key and value are always treated as data, instead of comparing them against a list of known flags.

## Reason
The wrapper blocked `-s`, `--script`, `-s=*` and `--script=*`. `fw_setenv` (libubootenv 0.3.5, `src/fw_printenv.c:76`) parses its arguments with `getopt_long` and the optstring `Vc:f:s:nhm:`, which accepts attached values (`-sFILE`) and abbreviations (`--scr=FILE`), so those forms passed the filter and reached `fw_setenv` as options. `-c` (attacker-chosen config) was not covered by the blocklist at all. GNU getopt also keeps scanning after the first positional argument, so the value position is enough. With `--`, all three arrive as positional data instead.

The sudoers rules (`sudo/omnect-device-service-uboot`) pin the key but pass the value unfiltered for `factory-reset`, `omnect_extra_bootargs` and `omnect_validate_extra_bootargs`. There is no live path from the twin into those values today, so this is defense in depth, not a fix for an exploitable escalation:

- `factory-reset`: the value is `serde_json::to_string(&cmd)?` (`src/twin/factory_reset.rs:259`) and always starts with `{`, so getopt cannot read it as an option. The `preserve` topics are validated against `factory_reset_keys()` first.
- `omnect_extra_bootargs` / `omnect_validate_extra_bootargs`: the value is `merge_bootargs()` over `/boot/omnect_extra_bootargs_omnect` and `/boot/omnect_extra_bootargs_custom` (`src/twin/firmware_update/mod.rs:490-497`) — files from the update image, not twin properties.

What the wrapper does have to hold is the argument count. sudo matches command line arguments as one concatenated string (`man 5 sudoers`, "Wildcards in command arguments"), so a rule like `fw_setenv_no_script.sh omnect_extra_bootargs *` also matches extra arguments. `[[ $# -ne 2 ]]` rejects those; `--` covers what arrives as key or value.

`tests/fw_setenv_wrapper.rs` pins the argument contract against a stub `fw_setenv`, so dropping `--` later fails the test. Two cases are worth naming: a value with spaces stays one argument, which is the shape the sudo concatenation rule is about; and an empty value must still be forwarded, because without the quotes around `$VALUE` the call would become `fw_setenv -- KEY`, a variable delete that only the separate `unset:` rules are meant to do. libubootenv's own parsing stays out of scope — only a real `fw_setenv` can show it, which needs a device test.

This is the repo's first `tests/` target, and the documented lint command does not reach it. `project-context.md` now lists `cargo clippy --features mock --all-targets -- -D warnings` alongside the existing one, and records why it has to be `mock`: the self dev-dependency in `Cargo.toml` turns that feature on, so pairing `--all-targets` with a bootloader feature gives the build script both features at once and trips its mutual-exclusion check. The same file gains an entry for the `tests/` directory and a **Test location** constraint, since until now every test lived in a `#[cfg(test)] mod` next to the code.

The wrapper's own contract is unchanged: two arguments, script mode not permitted — it is now structurally impossible rather than filtered, so the file name still applies and no caller, sudoers rule or recipe needs a change.
