### PR TITLE
fix(update_validation): name the pending stage on a validation timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-device-service"
-version = "0.45.1"
+version = "0.45.2"
 dependencies = [
  "actix-server",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-device-service"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-device-service.git"
-version = "0.45.1"
+version = "0.45.2"
 
 [dependencies]
 actix-server = { version = "2.6", default-features = false }

--- a/src/twin/firmware_update/update_validation.rs
+++ b/src/twin/firmware_update/update_validation.rs
@@ -46,17 +46,19 @@ fn health_deadline(remaining: Duration) -> Duration {
 enum ValidationStage {
     Authentication = 0,
     SystemHealth = 1,
-    StartAduAgent = 2,
+    EnableAduAgent = 2,
     Finalize = 3,
 }
 
 impl ValidationStage {
+    // an unknown value falls back to the first stage: claiming a late stage
+    // would point the reader away from the one that actually hung
     fn from_u8(value: u8) -> Self {
         match value {
-            0 => Self::Authentication,
             1 => Self::SystemHealth,
-            2 => Self::StartAduAgent,
-            _ => Self::Finalize,
+            2 => Self::EnableAduAgent,
+            3 => Self::Finalize,
+            _ => Self::Authentication,
         }
     }
 
@@ -66,7 +68,7 @@ impl ValidationStage {
         match self {
             Self::Authentication => "timeout waiting for authentication",
             Self::SystemHealth => "timeout waiting for system health",
-            Self::StartAduAgent => "timeout starting adu agent",
+            Self::EnableAduAgent => "timeout enabling adu agent",
             Self::Finalize => "timeout finalizing update",
         }
     }
@@ -226,8 +228,6 @@ impl UpdateValidation {
     }
 
     async fn wait_for_healthy(deadline: Instant) -> Result<()> {
-        debug!("validate update");
-
         let remaining = deadline.saturating_duration_since(Instant::now());
         systemd::wait_for_system_healthy(health_deadline(remaining)).await?;
 
@@ -236,7 +236,7 @@ impl UpdateValidation {
         Ok(())
     }
 
-    async fn start_adu_agent(local_update: bool) -> Result<()> {
+    async fn enable_adu_agent(local_update: bool) -> Result<()> {
         // remove iot-hub-device-service barrier file and start service as part of validation
         debug!("starting {IOT_HUB_DEVICE_UPDATE_SERVICE}");
         fs::remove_file(UPDATE_VALIDATION_FILE).context("remove UPDATE_VALIDATION_FILE")?;
@@ -328,8 +328,8 @@ impl UpdateValidation {
                 observe_stage.set(ValidationStage::SystemHealth);
                 Self::wait_for_healthy(deadline).await?;
 
-                observe_stage.set(ValidationStage::StartAduAgent);
-                Self::start_adu_agent(local_update).await?;
+                observe_stage.set(ValidationStage::EnableAduAgent);
+                Self::enable_adu_agent(local_update).await?;
 
                 observe_stage.set(ValidationStage::Finalize);
                 Self::finalize(status).await
@@ -428,10 +428,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn timeout_reports_pending_adu_agent_start() {
+    async fn timeout_reports_pending_adu_agent_enable() {
         assert_eq!(
-            timeout_message_for(ValidationStage::StartAduAgent).await,
-            "timeout starting adu agent"
+            timeout_message_for(ValidationStage::EnableAduAgent).await,
+            "timeout enabling adu agent"
         );
     }
 
@@ -458,6 +458,14 @@ mod tests {
     #[test]
     fn stage_tracker_starts_at_authentication() {
         assert_eq!(StageTracker::new().get(), ValidationStage::Authentication);
+    }
+
+    #[test]
+    fn unknown_stage_value_falls_back_to_authentication() {
+        assert_eq!(
+            ValidationStage::from_u8(ValidationStage::Finalize as u8 + 1),
+            ValidationStage::Authentication
+        );
     }
 
     #[test]

--- a/src/twin/firmware_update/update_validation.rs
+++ b/src/twin/firmware_update/update_validation.rs
@@ -10,8 +10,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{
     env, fs,
+    future::Future,
     path::Path,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicU8, Ordering},
+    },
     time::{Instant, SystemTime},
 };
 use tokio::{
@@ -35,6 +39,69 @@ static SYSTEM_HEALTHY_DEADLINE_MARGIN_IN_SECS: u64 = 30;
 // the generic validation timeout, which decides the reboot reason
 fn health_deadline(remaining: Duration) -> Duration {
     remaining.saturating_sub(Duration::from_secs(SYSTEM_HEALTHY_DEADLINE_MARGIN_IN_SECS))
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
+enum ValidationStage {
+    Authentication = 0,
+    SystemHealth = 1,
+    StartAduAgent = 2,
+    Finalize = 3,
+}
+
+impl ValidationStage {
+    fn from_u8(value: u8) -> Self {
+        match value {
+            0 => Self::Authentication,
+            1 => Self::SystemHealth,
+            2 => Self::StartAduAgent,
+            _ => Self::Finalize,
+        }
+    }
+
+    // ends up in extra_info, which is written to a fixed size pmsg record
+    // shared by several reboot reasons, so keep it short
+    fn timeout_message(&self) -> &'static str {
+        match self {
+            Self::Authentication => "timeout waiting for authentication",
+            Self::SystemHealth => "timeout waiting for system health",
+            Self::StartAduAgent => "timeout starting adu agent",
+            Self::Finalize => "timeout finalizing update",
+        }
+    }
+}
+
+// the validation runs in a spawned task, so its current stage must be readable
+// from the outside to tell a timeout what was still pending
+#[derive(Clone)]
+struct StageTracker(Arc<AtomicU8>);
+
+impl StageTracker {
+    fn new() -> Self {
+        Self(Arc::new(AtomicU8::new(
+            ValidationStage::Authentication as u8,
+        )))
+    }
+
+    fn set(&self, stage: ValidationStage) {
+        self.0.store(stage as u8, Ordering::Relaxed);
+    }
+
+    fn get(&self) -> ValidationStage {
+        ValidationStage::from_u8(self.0.load(Ordering::Relaxed))
+    }
+}
+
+async fn observe_with_stage_timeout(
+    duration: Duration,
+    stage: StageTracker,
+    observe: impl Future<Output = Result<()>>,
+) -> Result<()> {
+    match timeout(duration, observe).await {
+        Ok(result) => result,
+        Err(_) => anyhow::bail!("{}", stage.get().timeout_message()),
+    }
 }
 
 #[derive(Clone, Debug, Default, Serialize)]
@@ -158,7 +225,7 @@ impl UpdateValidation {
         Ok(())
     }
 
-    async fn validate(local_update: bool, deadline: Instant) -> Result<()> {
+    async fn wait_for_healthy(deadline: Instant) -> Result<()> {
         debug!("validate update");
 
         let remaining = deadline.saturating_duration_since(Instant::now());
@@ -166,6 +233,10 @@ impl UpdateValidation {
 
         info!("system is healthy");
 
+        Ok(())
+    }
+
+    async fn start_adu_agent(local_update: bool) -> Result<()> {
         // remove iot-hub-device-service barrier file and start service as part of validation
         debug!("starting {IOT_HUB_DEVICE_UPDATE_SERVICE}");
         fs::remove_file(UPDATE_VALIDATION_FILE).context("remove UPDATE_VALIDATION_FILE")?;
@@ -241,6 +312,8 @@ impl UpdateValidation {
         let deadline = Instant::now() + remaining_time;
         let status = Arc::clone(&self.status);
         let local_update = self.local_update;
+        let stage = StageTracker::new();
+        let observe_stage = stage.clone();
         self.tx_cancel_timer = Some(tx_cancel_timer);
         tokio::spawn(async move {
             info!("observe update with timeout: {}s", remaining_time.as_secs());
@@ -252,15 +325,19 @@ impl UpdateValidation {
                     return Ok(());
                 }
 
-                Self::validate(local_update, deadline).await?;
+                observe_stage.set(ValidationStage::SystemHealth);
+                Self::wait_for_healthy(deadline).await?;
+
+                observe_stage.set(ValidationStage::StartAduAgent);
+                Self::start_adu_agent(local_update).await?;
+
+                observe_stage.set(ValidationStage::Finalize);
                 Self::finalize(status).await
             };
 
-            let error = match timeout(remaining_time, observe_update).await {
-                Ok(Ok(())) => None,
-                Ok(Err(e)) => Some(e),
-                Err(e) => Some(anyhow::anyhow!(e.to_string())),
-            };
+            let error = observe_with_stage_timeout(remaining_time, stage, observe_update)
+                .await
+                .err();
 
             if let Some(e) = error {
                 error!("update validation failed: {e:#}");
@@ -314,6 +391,74 @@ mod tests {
     use super::*;
 
     use crate::bootloader_env::TEST_LOCK as BOOTARGS_TEST_LOCK;
+
+    const TEST_TIMEOUT: Duration = Duration::from_millis(50);
+
+    // run into the timeout while the given stage is pending and return what the
+    // reboot reason would report
+    async fn timeout_message_for(stage: ValidationStage) -> String {
+        let tracker = StageTracker::new();
+        let observe_stage = tracker.clone();
+        let pending = async move {
+            observe_stage.set(stage);
+            std::future::pending::<()>().await;
+            Ok(())
+        };
+
+        observe_with_stage_timeout(TEST_TIMEOUT, tracker, pending)
+            .await
+            .expect_err("expected a timeout")
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn timeout_reports_pending_authentication() {
+        assert_eq!(
+            timeout_message_for(ValidationStage::Authentication).await,
+            "timeout waiting for authentication"
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_reports_pending_system_health() {
+        assert_eq!(
+            timeout_message_for(ValidationStage::SystemHealth).await,
+            "timeout waiting for system health"
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_reports_pending_adu_agent_start() {
+        assert_eq!(
+            timeout_message_for(ValidationStage::StartAduAgent).await,
+            "timeout starting adu agent"
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_reports_pending_finalize() {
+        assert_eq!(
+            timeout_message_for(ValidationStage::Finalize).await,
+            "timeout finalizing update"
+        );
+    }
+
+    #[tokio::test]
+    async fn without_timeout_the_observed_result_is_kept() {
+        let tracker = StageTracker::new();
+        let err = observe_with_stage_timeout(TEST_TIMEOUT, tracker, async {
+            anyhow::bail!("some validation error")
+        })
+        .await
+        .expect_err("expected the observed error");
+
+        assert_eq!(err.to_string(), "some validation error");
+    }
+
+    #[test]
+    fn stage_tracker_starts_at_authentication() {
+        assert_eq!(StageTracker::new().get(), ValidationStage::Authentication);
+    }
 
     #[test]
     fn health_deadline_keeps_margin_to_validation_timeout() {


### PR DESCRIPTION
## Summary

When the update validation timeout fires, the reboot reason `swupdate-validation-failed` now reports which stage was still pending instead of tokio's generic `deadline has elapsed`: `timeout waiting for authentication`, `timeout waiting for system health`, `timeout starting adu agent` or `timeout finalizing update`. The validation task records its stage in a shared atomic, and the timeout arm reads it. `validate()` is split into `wait_for_healthy()` and `start_adu_agent()` so all stage transitions are visible in one place.

## Reason

The old message said nothing about what the validation was doing. A device that boots, waits for IoT Hub authentication that never comes (NTP not synced) and one that hangs in the health check produced the exact same reboot reason, so the failing stage was invisible after the reboot. The messages stay short because `extra_info` goes into a fixed size pmsg record shared by several reboot reasons.